### PR TITLE
examples: Added UHD library dir to CMakeLists.txt

### DIFF
--- a/srslte/examples/CMakeLists.txt
+++ b/srslte/examples/CMakeLists.txt
@@ -19,6 +19,9 @@
 # and at http://www.gnu.org/licenses/.
 #
 
+IF(UHD_FOUND)
+  LINK_DIRECTORIES(${UHD_LIBRARY_DIRS})
+ENDIF(UHD_FOUND)
 
 #################################################################
 # EXAMPLES


### PR DESCRIPTION
without, linkage fails if UHD shared library is not installed in the
default location on Fedora 22.