### PR TITLE
pdsch_enode: write requested number of frames to file

### DIFF
--- a/srslte/examples/pdsch_enodeb.c
+++ b/srslte/examples/pdsch_enodeb.c
@@ -653,8 +653,8 @@ int main(int argc, char **argv) {
         start_of_burst=false; 
 #endif
       }
-      nf++;
     }
+    nf++;
     sfn = (sfn + 1) % 1024;
   }
 


### PR DESCRIPTION
In pdsch_enode, when requesting "nf" frames be written to file, only 1 full frame was written. The "nf++" index increment line was inside the subframe for loop. This edit pulls it outside the for loop so that "nf" full frames are written to file.