### PR TITLE
Update FindMATLAB.cmake

### DIFF
--- a/cmake/modules/FindMATLAB.cmake
+++ b/cmake/modules/FindMATLAB.cmake
@@ -93,7 +93,7 @@ else()
     IF (MATLAB_BIN_EXISTS)
       execute_process(
         COMMAND which matlab
-        COMMAND xargs readlink
+        COMMAND xargs realpath
         COMMAND xargs dirname
         COMMAND xargs dirname
         COMMAND xargs echo -n


### PR DESCRIPTION
There are two problems with `readlink`:
1) it might give a path relative to the symlink location,
2) if matlab bin directory is in $PATH it will yield nothing.
The use of `realpath` solves both of them.