### PR TITLE
free UHD handles upon RF closure

### DIFF
--- a/srslte/lib/rf/rf_uhd_imp.c
+++ b/srslte/lib/rf/rf_uhd_imp.c
@@ -284,6 +284,8 @@ int rf_uhd_open(char *args, void **h)
       }
     }        
     
+    uhd_string_vector_free(&devices_str);
+    
     /* Create UHD handler */
     printf("Opening USRP with args: %s\n", args);
     uhd_error error = uhd_usrp_make(&handler->usrp, args);
@@ -358,6 +360,19 @@ int rf_uhd_open(char *args, void **h)
 int rf_uhd_close(void *h)
 {
   rf_uhd_stop_rx_stream(h);
+  
+  rf_uhd_handler_t *handler = (rf_uhd_handler_t*) h;
+  
+  uhd_tx_metadata_free(&handler->tx_md);
+  uhd_rx_metadata_free(&handler->rx_md_first);
+  uhd_rx_metadata_free(&handler->rx_md);
+  uhd_meta_range_free(&handler->rx_gain_range);
+  uhd_tx_streamer_free(&handler->tx_stream);
+  uhd_rx_streamer_free(&handler->rx_stream);
+  if (handler->has_rssi) {
+    uhd_sensor_value_free(&handler->rssi_value);
+  }
+  uhd_usrp_free(&handler->usrp);
   
   /** Something else to close the USRP?? */
   return 0;


### PR DESCRIPTION
We free `devices_str` inside `rf_uhd_open` since it's in local scope.