### PR TITLE
coverity: timeval.tv_usec is 'long int', not 'int'

### DIFF
--- a/srslte/examples/synch_file.c
+++ b/srslte/examples/synch_file.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
   }
   gettimeofday(&tdata[2], NULL);
   get_time_interval(tdata);
-  printf("done in %d s %d ms\n", (int) tdata[0].tv_sec, (int) tdata[0].tv_usec/1000);
+  printf("done in %ld s %ld ms\n", (int) tdata[0].tv_sec, (int) tdata[0].tv_usec/1000);
 
   printf("\n\tFr.Cnt\tN_id_2\tN_id_1\tSubf\tPSS Peak/Avg\tIdx\tm0\tm1\tCFO\n");
   printf("\t===============================================================================\n");

--- a/srslte/lib/ch_estimation/test/refsignal_ul_test.c
+++ b/srslte/lib/ch_estimation/test/refsignal_ul_test.c
@@ -131,13 +131,13 @@ int main(int argc, char **argv) {
               srslte_refsignal_dmrs_pusch_gen(&refs, nof_prb, sf_idx, cshift_dmrs, signal);              
               gettimeofday(&t[2], NULL);
               get_time_interval(t);
-              printf("DMRS ExecTime: %d us\n", t[0].tv_usec);
+              printf("DMRS ExecTime: %ld us\n", t[0].tv_usec);
 
               gettimeofday(&t[1], NULL);
               srslte_refsignal_srs_gen(&refs, sf_idx, signal);
               gettimeofday(&t[2], NULL);
               get_time_interval(t);
-              printf("SRS ExecTime: %d us\n", t[0].tv_usec);
+              printf("SRS ExecTime: %ld us\n", t[0].tv_usec);
             }
           }
         }

--- a/srslte/lib/mimo/test/precoding_test.c
+++ b/srslte/lib/mimo/test/precoding_test.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
   }
   gettimeofday(&t[2], NULL);
   get_time_interval(t);
-  printf("Execution Time: %d us\n", t[0].tv_usec);
+  printf("Execution Time: %ld us\n", t[0].tv_usec);
   
   /* check errors */
   mse = 0;

--- a/srslte/lib/modem/test/modem_test.c
+++ b/srslte/lib/modem/test/modem_test.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
   gettimeofday(&t[2], NULL);
   get_time_interval(t);
   
-  printf("Bit: %d us\n", t[0].tv_usec);
+  printf("Bit: %ld us\n", t[0].tv_usec);
   
   /* Test packed implementation */
   srslte_bit_pack_vector(input, input_bytes, num_bits);
@@ -170,8 +170,8 @@ int main(int argc, char **argv) {
   gettimeofday(&t[2], NULL);
   get_time_interval(t);
   
-  printf("Byte: %d us\n", t[0].tv_usec);
   
+  printf("Byte: %ld us\n", t[0].tv_usec);
   for (int i=0;i<num_bits/mod.nbits_x_symbol;i++) {
     if (symbols[i] != symbols_bytes[i]) {
       printf("error in symbol %d\n", i);
@@ -183,8 +183,8 @@ int main(int argc, char **argv) {
   gettimeofday(&x, NULL);
   srslte_demod_soft_demodulate(modulation, symbols, llr, num_bits / mod.nbits_x_symbol);
   gettimeofday(&y, NULL);
-  printf("\nElapsed time [ns]: %d\n", (int) y.tv_usec - (int) x.tv_usec);
   
+  printf("\nElapsed time [ns]: %ld\n", (int) y.tv_usec - (int) x.tv_usec);
   for (i=0;i<num_bits;i++) {
     output[i] = llr[i]>=0 ? 1 : 0;
   }

--- a/srslte/lib/phch/sch.c
+++ b/srslte/lib/phch/sch.c
@@ -654,7 +654,7 @@ int srslte_ulsch_uci_decode(srslte_sch_t *q, srslte_pusch_cfg_t *cfg, srslte_sof
                                       uci_data->uci_cqi, &uci_data->cqi_ack);
     gettimeofday(&t[2], NULL);
     get_time_interval(t);
-    printf("texec=%d us\n", t[0].tv_usec);
+    printf("texec=%ld us\n", t[0].tv_usec);
     
     if (ret < 0) {
       return ret; 

--- a/srslte/lib/phch/test/prach_test.c
+++ b/srslte/lib/phch/test/prach_test.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
     srslte_prach_detect(p, frequency_offset, &preamble[p->N_cp], prach_len, indices, &n_indices);
     gettimeofday(&t[2], NULL);
     get_time_interval(t);
-    printf("texec=%d us\n", t[0].tv_usec);
+    printf("texec=%ld us\n", t[0].tv_usec);
     if(n_indices != 1 || indices[0] != seq_index)
       return -1;
   }

--- a/srslte/lib/phch/test/pucch_test.c
+++ b/srslte/lib/phch/test/pucch_test.c
@@ -156,7 +156,7 @@ int main(int argc, char **argv) {
           }     
           gettimeofday(&t[2], NULL);
           get_time_interval(t);
-          INFO("format %d, n_pucch: %d, ncs: %d, d: %d, t_exec=%d us\n", format, n_pucch, ncs, d, t[0].tv_usec);
+          INFO("format %d, n_pucch: %d, ncs: %d, d: %d, t_exec=%ld us\n", format, n_pucch, ncs, d, t[0].tv_usec);
         }
       }
     }    

--- a/srslte/lib/scrambling/test/scrambling_test.c
+++ b/srslte/lib/scrambling/test/scrambling_test.c
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
     srslte_scrambling_b(&seq, scrambled_b);
 
     get_time_interval(t);
-    printf("Texec=%d us for %d bits\n", t[0].tv_usec, seq.len);
+    printf("Texec=%ld us for %d bits\n", t[0].tv_usec, seq.len);
     
     for (i=0;i<seq.len;i++) {
       if (scrambled_b[i] != input_b[i]) {
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
     srslte_scrambling_f(&seq, scrambled_f);
 
     get_time_interval(t);
-    printf("Texec=%d us for %d bits\n", t[0].tv_usec, seq.len);
+    printf("Texec=%ld us for %d bits\n", t[0].tv_usec, seq.len);
 
     for (i=0;i<seq.len;i++) {
       if (scrambled_f[i] != input_f[i]) {


### PR DESCRIPTION
Should solve some PW.PRINTF_ARG_MISMATCH issues