### PR TITLE
Do not demote timeval members to int ; fix elapsed time unit in modem test

### DIFF
--- a/srslte/examples/synch_file.c
+++ b/srslte/examples/synch_file.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
   }
   gettimeofday(&tdata[2], NULL);
   get_time_interval(tdata);
-  printf("done in %ld s %ld ms\n", (int) tdata[0].tv_sec, (int) tdata[0].tv_usec/1000);
+  printf("done in %ld s %ld ms\n", tdata[0].tv_sec, tdata[0].tv_usec/1000);
 
   printf("\n\tFr.Cnt\tN_id_2\tN_id_1\tSubf\tPSS Peak/Avg\tIdx\tm0\tm1\tCFO\n");
   printf("\t===============================================================================\n");

--- a/srslte/lib/modem/test/modem_test.c
+++ b/srslte/lib/modem/test/modem_test.c
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
   srslte_demod_soft_demodulate(modulation, symbols, llr, num_bits / mod.nbits_x_symbol);
   gettimeofday(&y, NULL);
   
-  printf("\nElapsed time [ns]: %ld\n", (int) y.tv_usec - (int) x.tv_usec);
+  printf("\nElapsed time [us]: %ld\n", y.tv_usec - x.tv_usec);
   for (i=0;i<num_bits;i++) {
     output[i] = llr[i]>=0 ? 1 : 0;
   }


### PR DESCRIPTION
I introduced these coverity issues in my last PR ; sorry about that