### PR TITLE
Fixed bug in srslte_prach_tti_opportunity()

### DIFF
--- a/srslte/lib/phch/prach.c
+++ b/srslte/lib/phch/prach.c
@@ -195,6 +195,11 @@ bool srslte_prach_tti_opportunity(srslte_prach_t *p, uint32_t current_tti, int a
   // Get SFN and sf_idx from the PRACH configuration index
   srslte_prach_sfn_t prach_sfn = srslte_prach_get_sfn(config_idx);  
 
+  // This is the only option which provides always an opportunity for PRACH transmission.
+  if(config_idx == 14) {
+    return true;
+  }
+
   if ((prach_sfn == SRSLTE_PRACH_SFN_EVEN && ((current_tti/10)%2)==0) ||
       prach_sfn == SRSLTE_PRACH_SFN_ANY) 
   {


### PR DESCRIPTION
This PRACH opportunity routine was mis-considering the option 14 of the PRACH Configuration Index table present in 3GPP specifications 36.211, 5.7.1-2. Basically the setup of `prach_sf_config` private table of `prach.c` file is correct in all the other options (`index%16`), but in the case of 14 it's wrong.

As for the other options, when selecting this entry in the table (the 15th), you assume that the `nof_sf` of the `srslte_prach_sf_config_t` structure is -1, and this will ultimately skip the sub-frames nested loop and returns always false. As result option 14 opportunity check always returned false, instead of always true (as 3GPP table indicates).

By inserting a quick check specialized for this option (PRACH Configuration Index 14) at the begin, you skip any additional and useless test and always return true, which is the mandatory value for such option.