### PR TITLE
Link several binaries and tests with the fftw3f library

### DIFF
--- a/lib/examples/CMakeLists.txt
+++ b/lib/examples/CMakeLists.txt
@@ -24,7 +24,7 @@
 #################################################################
 
 add_executable(synch_file synch_file.c)
-target_link_libraries(synch_file srslte_phy)
+target_link_libraries(synch_file srslte_phy ${FFTW3F_LIBRARY})
 
 #################################################################
 # These can be compiled without UHD or graphics support
@@ -32,18 +32,18 @@ target_link_libraries(synch_file srslte_phy)
 
 if(RF_FOUND)
   add_executable(pdsch_ue pdsch_ue.c)
-  target_link_libraries(pdsch_ue srslte_phy srslte_rf pthread)
+  target_link_libraries(pdsch_ue srslte_phy srslte_rf ${FFTW3F_LIBRARY} pthread)
 
   add_executable(pdsch_enodeb pdsch_enodeb.c)
-  target_link_libraries(pdsch_enodeb srslte_phy srslte_rf pthread)
+  target_link_libraries(pdsch_enodeb srslte_phy srslte_rf ${FFTW3F_LIBRARY} pthread)
 else(RF_FOUND)
   add_definitions(-DDISABLE_RF)
 
   add_executable(pdsch_ue pdsch_ue.c)
-  target_link_libraries(pdsch_ue srslte_phy pthread)
+  target_link_libraries(pdsch_ue srslte_phy ${FFTW3F_LIBRARY} pthread)
 
   add_executable(pdsch_enodeb pdsch_enodeb.c)
-  target_link_libraries(pdsch_enodeb srslte_phy pthread)
+  target_link_libraries(pdsch_enodeb srslte_phy ${FFTW3F_LIBRARY} pthread)
 endif(RF_FOUND)
 
 find_package(SRSGUI)
@@ -63,16 +63,16 @@ endif(SRSGUI_FOUND)
 if(RF_FOUND)
 
   add_executable(cell_search cell_search.c)
-  target_link_libraries(cell_search srslte_phy srslte_rf)
+  target_link_libraries(cell_search srslte_phy srslte_rf ${FFTW3F_LIBRARY})
 
   add_executable(cell_measurement cell_measurement.c)
-  target_link_libraries(cell_measurement srslte_phy srslte_rf)
+  target_link_libraries(cell_measurement srslte_phy srslte_rf ${FFTW3F_LIBRARY})
 
   add_executable(usrp_capture usrp_capture.c)
   target_link_libraries(usrp_capture srslte_phy srslte_rf)
 
   add_executable(usrp_capture_sync usrp_capture_sync.c)
-  target_link_libraries(usrp_capture_sync srslte_phy srslte_rf)
+  target_link_libraries(usrp_capture_sync srslte_phy srslte_rf ${FFTW3F_LIBRARY})
 
   add_executable(usrp_txrx usrp_txrx.c)
   target_link_libraries(usrp_txrx srslte_phy srslte_rf)

--- a/lib/src/phy/ch_estimation/test/CMakeLists.txt
+++ b/lib/src/phy/ch_estimation/test/CMakeLists.txt
@@ -23,7 +23,7 @@
 ########################################################################
 
 add_executable(chest_test_dl chest_test_dl.c)
-target_link_libraries(chest_test_dl srslte_phy)
+target_link_libraries(chest_test_dl srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(chest_test_dl_cellid0 chest_test_dl -c 0) 
 add_test(chest_test_dl_cellid1 chest_test_dl -c 1) 
@@ -39,10 +39,10 @@ add_test(chest_test_dl_cellid2 chest_test_dl -c 2 -r 50)
 ########################################################################
 
 add_executable(chest_test_ul chest_test_ul.c)
-target_link_libraries(chest_test_ul srslte_phy)
+target_link_libraries(chest_test_ul srslte_phy ${FFTW3F_LIBRARY})
 
 add_executable(refsignal_ul_test_all refsignal_ul_test.c)
-target_link_libraries(refsignal_ul_test_all srslte_phy)
+target_link_libraries(refsignal_ul_test_all srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(chest_test_ul_cellid0 chest_test_ul -c 0 -r 50) 
 add_test(chest_test_ul_cellid1 chest_test_ul -c 1 -r 50) 

--- a/lib/src/phy/dft/test/CMakeLists.txt
+++ b/lib/src/phy/dft/test/CMakeLists.txt
@@ -23,7 +23,7 @@
 ########################################################################
 
 add_executable(ofdm_test ofdm_test.c)
-target_link_libraries(ofdm_test srslte_phy)
+target_link_libraries(ofdm_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(ofdm_normal ofdm_test) 
 add_test(ofdm_extended ofdm_test -e) 

--- a/lib/src/phy/phch/test/CMakeLists.txt
+++ b/lib/src/phy/phch/test/CMakeLists.txt
@@ -80,7 +80,7 @@ add_test(pdcch_test pdcch_test)
 ########################################################################
 
 add_executable(pdsch_test pdsch_test.c)
-target_link_libraries(pdsch_test srslte_phy)
+target_link_libraries(pdsch_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(pdsch_test_qpsk pdsch_test -m 10 -n 50 -r 1)
 add_test(pdsch_test_qam16 pdsch_test -m 20 -n 100)
@@ -165,7 +165,7 @@ add_test(pdsch_test_multiplex2cw_p1_100 pdsch_test -x multiplex -a 2 -t 0 -p 1 -
 
 
 add_executable(pmch_test pmch_test.c)
-target_link_libraries(pmch_test srslte_phy)
+target_link_libraries(pmch_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(pmch_test_qpsk pmch_test -m 6 -n 50)
 add_test(pmch_test_qam16 pmch_test -m 15 -n 100)
@@ -177,22 +177,22 @@ add_test(pmch_test_qam64 pmch_test -m 25 -n 100)
 ########################################################################
 
 add_executable(pbch_file_test pbch_file_test.c)
-target_link_libraries(pbch_file_test srslte_phy)
+target_link_libraries(pbch_file_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_executable(pcfich_file_test pcfich_file_test.c)
-target_link_libraries(pcfich_file_test srslte_phy)
+target_link_libraries(pcfich_file_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_executable(phich_file_test phich_file_test.c)
-target_link_libraries(phich_file_test srslte_phy)
+target_link_libraries(phich_file_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_executable(pdcch_file_test pdcch_file_test.c)
-target_link_libraries(pdcch_file_test srslte_phy)
+target_link_libraries(pdcch_file_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_executable(pdsch_pdcch_file_test pdsch_pdcch_file_test.c)
-target_link_libraries(pdsch_pdcch_file_test srslte_phy)
+target_link_libraries(pdsch_pdcch_file_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_executable(pmch_file_test pmch_file_test.c)
-target_link_libraries(pmch_file_test srslte_phy)
+target_link_libraries(pmch_file_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(pbch_file_test pbch_file_test -i ${CMAKE_CURRENT_SOURCE_DIR}/signal.1.92M.dat) 
 add_test(pcfich_file_test pcfich_file_test -c 150 -n 50 -p 2 -i ${CMAKE_CURRENT_SOURCE_DIR}/signal.10M.dat) 
@@ -206,7 +206,7 @@ add_test(pmch_file_test pmch_file_test  -i ${CMAKE_CURRENT_SOURCE_DIR}/pmch_100p
 ########################################################################
 
 add_executable(pusch_test pusch_test.c)
-target_link_libraries(pusch_test srslte_phy)
+target_link_libraries(pusch_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(pusch_test pusch_test)
 
@@ -215,7 +215,7 @@ add_test(pusch_test pusch_test)
 ########################################################################
 
 add_executable(pucch_test pucch_test.c)
-target_link_libraries(pucch_test srslte_phy)
+target_link_libraries(pucch_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(pucch_test pucch_test)
 
@@ -224,7 +224,7 @@ add_test(pucch_test pucch_test)
 ########################################################################
 
 add_executable(prach_test prach_test.c)
-target_link_libraries(prach_test srslte_phy)
+target_link_libraries(prach_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(prach prach_test)
 
@@ -248,7 +248,7 @@ add_test(prach_zc2 prach_test -z 2)
 add_test(prach_zc3 prach_test -z 3)
  
 add_executable(prach_test_multi prach_test_multi.c)
-target_link_libraries(prach_test_multi srslte_phy)
+target_link_libraries(prach_test_multi srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(prach_test_multi prach_test_multi)
 
@@ -260,5 +260,5 @@ add_test(prach_test_multi_n4 prach_test_multi -n 4)
 
 if(UHD_FOUND)
   add_executable(prach_test_usrp prach_test_usrp.c)
-  target_link_libraries(prach_test_usrp srslte_rf srslte_phy pthread)
+  target_link_libraries(prach_test_usrp srslte_rf srslte_phy ${FFTW3F_LIBRARY} pthread)
 endif(UHD_FOUND)

--- a/lib/src/phy/sync/test/CMakeLists.txt
+++ b/lib/src/phy/sync/test/CMakeLists.txt
@@ -25,11 +25,11 @@ find_package(SRSGUI)
 ########################################################################
 
 add_executable(pss_file pss_file.c)
-target_link_libraries(pss_file srslte_phy)
+target_link_libraries(pss_file srslte_phy ${FFTW3F_LIBRARY})
 
 if(UHD_FOUND)
   add_executable(pss_usrp pss_usrp.c)
-  target_link_libraries(pss_usrp srslte_phy srslte_rf)
+  target_link_libraries(pss_usrp srslte_phy srslte_rf ${FFTW3F_LIBRARY})
 endif(UHD_FOUND)
 
 
@@ -48,7 +48,7 @@ endif(SRSGUI_FOUND)
 ########################################################################
 
 add_executable(sync_test sync_test.c)
-target_link_libraries(sync_test srslte_phy)
+target_link_libraries(sync_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(sync_test_100 sync_test -o 100 -c 501)
 add_test(sync_test_400 sync_test -o 400 -c 2)

--- a/lib/src/phy/utils/test/CMakeLists.txt
+++ b/lib/src/phy/utils/test/CMakeLists.txt
@@ -23,7 +23,7 @@
 ########################################################################
 
 add_executable(dft_test dft_test.c)
-target_link_libraries(dft_test srslte_phy)
+target_link_libraries(dft_test srslte_phy ${FFTW3F_LIBRARY})
 
 add_test(dft_test dft_test)
 add_test(dft_reverse dft_test -b) # Backwards first

--- a/srsenb/src/CMakeLists.txt
+++ b/srsenb/src/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(srsenb  srsenb_upper
                               srslte_phy
                               srslte_upper
                               srslte_radio
+                              ${FFTW3F_LIBRARY}
                               ${CMAKE_THREAD_LIBS_INIT} 
                               ${Boost_LIBRARIES} 
                               ${SEC_LIBRARIES}

--- a/srsenb/test/mac/CMakeLists.txt
+++ b/srsenb/test/mac/CMakeLists.txt
@@ -5,5 +5,6 @@ target_link_libraries(scheduler_test  srsenb_mac
                                       srsenb_phy 
                                       srslte_common
                                       srslte_phy
+                                      ${FFTW3F_LIBRARY}
                                       ${CMAKE_THREAD_LIBS_INIT} 
                                       ${Boost_LIBRARIES})

--- a/srsenb/test/upper/CMakeLists.txt
+++ b/srsenb/test/upper/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(ip_test_enb srsenb_upper
                                   srslte_phy
                                   srslte_upper
                                   srslte_radio
+                                  ${FFTW3F_LIBRARY}
                                   ${CMAKE_THREAD_LIBS_INIT} 
                                   ${Boost_LIBRARIES} 
                                   ${SEC_LIBRARIES})

--- a/srsue/src/CMakeLists.txt
+++ b/srsue/src/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(srsue   srsue_mac
                               srslte_phy
                               srslte_upper
                               srslte_radio
+                              ${FFTW3F_LIBRARY}
                               ${CMAKE_THREAD_LIBS_INIT}
                               ${Boost_LIBRARIES})
 

--- a/srsue/test/mac/CMakeLists.txt
+++ b/srsue/test/mac/CMakeLists.txt
@@ -19,5 +19,5 @@
 #
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch")
 add_executable(mac_test mac_test.cc)
-target_link_libraries(mac_test srsue_mac srsue_phy srslte_common srslte_phy srslte_radio srslte_asn1 ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
+target_link_libraries(mac_test srsue_mac srsue_phy srslte_common srslte_phy srslte_radio srslte_asn1 ${FFTW3F_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
This fixes the various undefined reference linker errors when building srsLTE on Fedora 26.

../../libsrslte_phy.a(dft_fftw.c.o): In function `srslte_dft_exit':
dft_fftw.c:(.text+0x1c): undefined reference to `fftwf_export_wisdom_to_filename'
../../libsrslte_phy.a(dft_fftw.c.o): In function `srslte_dft_replan_c':
dft_fftw.c:(.text+0x7d): undefined reference to `fftwf_destroy_plan'
dft_fftw.c:(.text+0x9a): undefined reference to `fftwf_plan_dft_1d'
../../libsrslte_phy.a(dft_fftw.c.o): In function `srslte_dft_plan_c':
dft_fftw.c:(.text+0xe1): undefined reference to `fftwf_malloc'
dft_fftw.c:(.text+0xed): undefined reference to `fftwf_malloc'
dft_fftw.c:(.text+0x10c): undefined reference to `fftwf_plan_dft_1d'
../../libsrslte_phy.a(dft_fftw.c.o): In function `srslte_dft_replan_r':