### PR TITLE
Write SFN to MAC-LTE PCAP file

### DIFF
--- a/lib/include/srslte/common/pcap.h
+++ b/lib/include/srslte/common/pcap.h
@@ -80,8 +80,9 @@ typedef struct pcaprec_hdr_s {
 #define MAC_LTE_UEID_TAG            0x03
 /* 2 bytes, network order */
 
-#define MAC_LTE_SUBFRAME_TAG        0x04
+#define MAC_LTE_FRAME_SUBFRAME_TAG  0x04
 /* 2 bytes, network order */
+/* SFN is stored in 12 MSB and SF in 4 LSB */
 
 #define MAC_LTE_PREDFINED_DATA_TAG  0x05
 /* 1 byte */
@@ -150,7 +151,7 @@ inline int MAC_LTE_PCAP_WritePDU(FILE *fd, MAC_Context_Info_t *context,
     pcaprec_hdr_t packet_header;
     char context_header[256];
     int offset = 0;
-    unsigned short tmp16;
+    uint16_t tmp16;
 
     /* Can't write if file wasn't successfully opened */
     if (fd == NULL) {
@@ -176,9 +177,11 @@ inline int MAC_LTE_PCAP_WritePDU(FILE *fd, MAC_Context_Info_t *context,
     memcpy(context_header+offset, &tmp16, 2);
     offset += 2;
 
-    /* Subframe number */
-    context_header[offset++] = MAC_LTE_SUBFRAME_TAG;
-    tmp16 = htons(context->subFrameNumber);
+    /* Subframe Number and System Frame Number */
+    /* SFN is stored in 12 MSB and SF in 4 LSB */
+    context_header[offset++] = MAC_LTE_FRAME_SUBFRAME_TAG;
+    tmp16 = (context->sysFrameNumber << 4) | context->subFrameNumber;
+    tmp16 = htons(tmp16);
     memcpy(context_header+offset, &tmp16, 2);
     offset += 2;
 


### PR DESCRIPTION
This patch includes SysFrameNumber (SFN) in PCAP files, as it is expected by the Wireshark mac-lte dissector. The tag name was changed accordingly. I've just adapted the Wireshark implementation. If there's some standard, I'm not aware of it.

It seems to work just as intended, but please double-check.

The type change was just to make things clear to me, maybe the rest of `MAC_Context_Info_t` should use the explicit types, too. But might be more a theoretical problem.

## Wireshark MAC-LTE SFN Handling
[packet-mac-lte.c#L2327](https://github.com/wireshark/wireshark/blob/2832f4e97d77324b4e46aac40dae0ce898ae559d/epan/dissectors/packet-mac-lte.c#L2327)
```c
case MAC_LTE_FRAME_SUBFRAME_TAG:
{
  guint16 sfn_sf = tvb_get_ntohs(tvb, offset);
  p_mac_lte_info->sysframeNumber = (sfn_sf >> 4) & 0x03ff;
  p_mac_lte_info->subframeNumber = sfn_sf & 0x000f;
  offset += 2;
}
break;
```