### PR TITLE
use vector push_back method to allocate required

### DIFF
--- a/srsenb/src/phy/phy.cc
+++ b/srsenb/src/phy/phy.cc
@@ -91,7 +91,7 @@ bool phy::init(phy_args_t *args,
 {
   std::vector<void*> log_vec;
   for (int i=0;i<args->nof_phy_threads;i++) {
-    log_vec[i] = (void*) log_h;
+    log_vec.push_back((void*)log_h);
   }
   init(args, cfg, radio_handler_, mac, log_vec);
   return true; 


### PR DESCRIPTION
storage for log service objects vs using index operator.