### PR TITLE
Add APN to config and PDN connectivity request

### DIFF
--- a/lib/include/srslte/common/interfaces_common.h
+++ b/lib/include/srslte/common/interfaces_common.h
@@ -30,6 +30,7 @@
 #include "srslte/common/timers.h"
 #include "srslte/common/security.h"
 #include "srslte/asn1/liblte_rrc.h"
+#include <string>
 
 
 namespace srslte {
@@ -37,11 +38,13 @@ namespace srslte {
 class srslte_nas_config_t
 {
 public:
-  srslte_nas_config_t(uint32_t lcid_ = 0)
-    :lcid(lcid_)
+  srslte_nas_config_t(uint32_t lcid_ = 0, std::string apn_ = "")
+    :lcid(lcid_),
+     apn(apn_)
     {}
 
-  uint32_t lcid;
+  uint32_t    lcid;
+  std::string apn;
 };
 
 

--- a/srsue/hdr/ue_base.h
+++ b/srsue/hdr/ue_base.h
@@ -126,6 +126,7 @@ typedef struct {
   usim_args_t   usim;
   rrc_args_t    rrc;
   std::string   ue_category_str;
+  std::string   apn;
   expert_args_t expert;
 }all_args_t;
 

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -82,6 +82,7 @@ void parse_args(all_args_t *args, int argc, char *argv[]) {
                                                                                            "UECapabilityInformation message. Default 0xe6041c00")
     ("rrc.ue_category",   bpo::value<string>(&args->ue_category_str)->default_value("4"),  "UE Category (1 to 5)")
 
+    ("nas.apn",   bpo::value<string>(&args->apn)->default_value(""),  "Set Access Point Name (APN) for data services")
 
     ("pcap.enable", bpo::value<bool>(&args->pcap.enable)->default_value(false), "Enable MAC packet captures for wireshark")
     ("pcap.filename", bpo::value<string>(&args->pcap.filename)->default_value("ue.pcap"), "MAC layer capture filename")

--- a/srsue/src/ue.cc
+++ b/srsue/src/ue.cc
@@ -195,7 +195,8 @@ bool ue::init(all_args_t *args_)
   pdcp.init(&rlc, &rrc, &gw, &pdcp_log, 0 /* RB_ID_SRB0 */, SECURITY_DIRECTION_UPLINK);
 
   usim.init(&args->usim, &usim_log);
-  nas.init(&usim, &rrc, &gw, &nas_log, 1 /* RB_ID_SRB1 */);
+  srslte_nas_config_t nas_cfg(1, args->apn); /* RB_ID_SRB1 */
+  nas.init(&usim, &rrc, &gw, &nas_log, nas_cfg);
   gw.init(&pdcp, &nas, &gw_log, 3 /* RB_ID_DRB1 */);
 
   gw.set_netmask(args->expert.ip_netmask);

--- a/srsue/src/upper/nas.cc
+++ b/srsue/src/upper/nas.cc
@@ -884,7 +884,14 @@ void nas::gen_pdn_connectivity_request(LIBLTE_BYTE_MSG_STRUCT *msg) {
 
   // Set the optional flags
   pdn_con_req.esm_info_transfer_flag_present = false; //FIXME: Check if this is needed
-  pdn_con_req.apn_present = false;
+  if (cfg.apn == "") {
+    pdn_con_req.apn_present = false;
+  } else {
+    pdn_con_req.apn_present = true;
+    LIBLTE_MME_ACCESS_POINT_NAME_STRUCT apn;
+    apn.apn = cfg.apn;
+    pdn_con_req.apn = apn;
+  }
   pdn_con_req.protocol_cnfg_opts_present = false;
   pdn_con_req.device_properties_present = false;
 

--- a/srsue/ue.conf.example
+++ b/srsue/ue.conf.example
@@ -118,6 +118,15 @@ imei = 353490069873319
 #ue_category   = 4
 #feature_group = 0xe6041c00
 
+#####################################################################
+# NAS configuration
+#
+# apn:		Set Access Point Name (APN)
+#####################################################################
+[nas]
+# apn = internetinternet
+
+
 [gui]
 enable = false
 


### PR DESCRIPTION
This allows users to force an APN in PDN connectivity request.

Actually I'm not sure if the following line is ok, since I do not hand a pointer to `nas::init`, but the `struct` itself:
```cpp
srslte_nas_config_t nas_cfg(1, args->apn); /* RB_ID_SRB1 */
nas.init(&usim, &rrc, &gw, &nas_log, nas_cfg); 
```