### PR TITLE
Configurable MCC/MNC for milenage and xor algorithms

### DIFF
--- a/srsepc/hdr/hss/hss.h
+++ b/srsepc/hdr/hss/hss.h
@@ -46,6 +46,8 @@ namespace srsepc{
 typedef struct{
   std::string auth_algo;
   std::string db_file;
+  uint16_t mcc;
+  uint16_t mnc;
 }hss_args_t;
 
 typedef struct{
@@ -89,6 +91,8 @@ private:
   static hss *m_instance;
 
   uint64_t                  m_sqn; //48 bits
+  uint16_t                  m_mcc;
+  uint16_t                  m_mnc;
   srslte::byte_buffer_pool *m_pool;
   std::ifstream m_db_file;
 

--- a/srsepc/src/hss/hss.cc
+++ b/srsepc/src/hss/hss.cc
@@ -90,6 +90,9 @@ hss::init(hss_args_t *hss_args, srslte::log_filter *hss_log)
     return -1;
   }
 
+  m_mcc = hss_args->mcc;
+  m_mnc = hss_args->mnc;
+
   m_hss_log->info("HSS Initialized. DB file %s, authentication algorithm %s\n", hss_args->db_file.c_str(),hss_args->auth_algo.c_str());
   m_hss_log->console("HSS Initialized\n");
   return 0;
@@ -203,9 +206,6 @@ hss::gen_auth_info_answer_milenage(uint64_t imsi, uint8_t *k_asme, uint8_t *autn
   uint8_t     ak[6];
   uint8_t     mac[8];
 
-  uint16_t  mcc=61441; //001
-  uint16_t  mnc=65281; //01
-
   if(!get_k_amf_op(imsi,k,amf,op))
   {
     return false;
@@ -233,8 +233,8 @@ hss::gen_auth_info_answer_milenage(uint64_t imsi, uint8_t *k_asme, uint8_t *autn
                             ik,
                             ak,
                             sqn,
-                            mcc,
-                            mnc,
+                            m_mcc,
+                            m_mnc,
                             k_asme);
 
   //Generate AUTN (autn = sqn ^ ak |+| amf |+| mac)
@@ -273,9 +273,6 @@ hss::gen_auth_info_answer_xor(uint64_t imsi, uint8_t *k_asme, uint8_t *autn, uin
   uint8_t     ik[16];
   uint8_t     ak[6];
   uint8_t     mac[8];
-
-  uint16_t  mcc=61441; //001
-  uint16_t  mnc=65281; //01
 
   int i = 0;
 
@@ -332,8 +329,8 @@ hss::gen_auth_info_answer_xor(uint64_t imsi, uint8_t *k_asme, uint8_t *autn, uin
                             ik,
                             ak,
                             sqn,
-                            mcc,
-                            mnc,
+                            m_mcc,
+                            m_mnc,
                             k_asme);
 
   //Generate AUTN (autn = sqn ^ ak |+| amf |+| mac)

--- a/srsepc/src/main.cc
+++ b/srsepc/src/main.cc
@@ -200,6 +200,8 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
   args->spgw_args.sgi_if_addr = sgi_if_addr;
   args->hss_args.db_file = hss_db_file;
   args->hss_args.auth_algo = hss_auth_algo;
+  args->hss_args.mcc = args->mme_args.s1ap_args.mcc;
+  args->hss_args.mnc = args->mme_args.s1ap_args.mnc;
 
   // Apply all_level to any unset layers
   if (vm.count("log.all_level")) {


### PR DESCRIPTION
This patch replaces hardcoded MCC and MNC values by config values (otherwise only default values will work).
Added mcc and mnc to hss_args.
(possible duplicate of #137 but testet for milenage)