### PR TITLE
LIBLTE_S1AP_MESSAGE_INITIALCONTEXTSETUPRESPONSE_STRUCT initialization fix

### DIFF
--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -1069,6 +1069,9 @@ void rrc::ue::notify_s1ap_ue_ctxt_setup_complete()
 {
   LIBLTE_S1AP_MESSAGE_INITIALCONTEXTSETUPRESPONSE_STRUCT res;
   res.ext = false;
+  res.E_RABFailedToSetupListCtxtSURes_present = false;
+  res.CriticalityDiagnostics_present = false;
+
   res.E_RABSetupListCtxtSURes.len = 0;
   res.E_RABFailedToSetupListCtxtSURes.len = 0;
 


### PR DESCRIPTION
Initialize the E_RABFailedToSetupListCtxtSURes_present and CriticalityDiagnostics_present members of the LIBLTE_S1AP_MESSAGE_INITIALCONTEXTSETUPRESPONSE_STRUCT to false to prevent "[S1AP] [E] Failed to send InitialContextSetupResponse" errors. When these members are set to false the liblte_s1ap_pack_initialcontextsetupresponse (lib/src/asn1/liblte_s1ap.cc) routine ignores the corresponding (uninitialized) structures when serializing the response pdu.