### PR TITLE
NAS key enb derivation fix

### DIFF
--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -958,7 +958,7 @@ void rrc::ue::set_security_capabilities(LIBLTE_S1AP_UESECURITYCAPABILITIES_STRUC
 void rrc::ue::set_security_key(uint8_t* key, uint32_t length)
 {
   memcpy(k_enb, key, length);
-
+  parent->rrc_log->info_hex(k_enb, 32, "Key eNodeB (k_enb)");
   // Select algos (TODO: use security capabilities and config preferences)
   cipher_algo = srslte::CIPHERING_ALGORITHM_ID_EEA0;
   integ_algo  = srslte::INTEGRITY_ALGORITHM_ID_128_EIA1;

--- a/srsepc/hdr/mme/s1ap_nas_transport.h
+++ b/srsepc/hdr/mme/s1ap_nas_transport.h
@@ -47,7 +47,20 @@ public:
   bool handle_initial_ue_message(LIBLTE_S1AP_MESSAGE_INITIALUEMESSAGE_STRUCT *init_ue, struct sctp_sndrcvinfo *enb_sri, srslte::byte_buffer_t *reply_buffer, bool *reply_flag);
   bool handle_uplink_nas_transport(LIBLTE_S1AP_MESSAGE_UPLINKNASTRANSPORT_STRUCT *ul_xport, struct sctp_sndrcvinfo *enb_sri, srslte::byte_buffer_t *reply_buffer, bool *reply_flag);
 
-  //Initial UE messages
+  bool pack_attach_accept(ue_emm_ctx_t *ue_emm_ctx, ue_ecm_ctx_t *ue_ecm_ctx, LIBLTE_S1AP_E_RABTOBESETUPITEMCTXTSUREQ_STRUCT *erab_ctxt, struct srslte::gtpc_pdn_address_allocation_ie *paa, srslte::byte_buffer_t *nas_buffer);
+
+private:
+  s1ap_nas_transport();
+  virtual ~s1ap_nas_transport();
+
+  srslte::log *m_s1ap_log;
+  srslte::byte_buffer_pool *m_pool;
+
+  s1ap* m_s1ap;
+  hss_interface_s1ap*  m_hss;
+  mme_gtpc* m_mme_gtpc;
+
+    //Initial UE messages
   bool handle_nas_attach_request( uint32_t enb_ue_s1ap_id,
                                   srslte::byte_buffer_t *nas_msg,
                                   srslte::byte_buffer_t *reply_buffer,
@@ -107,7 +120,6 @@ public:
   bool pack_security_mode_command(srslte::byte_buffer_t *reply_msg, ue_emm_ctx_t *ue_emm_ctx, ue_ecm_ctx_t *ue_ecm_ctx);
   bool pack_esm_information_request(srslte::byte_buffer_t *reply_msg, ue_emm_ctx_t *ue_emm_ctx, ue_ecm_ctx_t *ue_ecm_ctx);
 
-  bool pack_attach_accept(ue_emm_ctx_t *ue_emm_ctx, ue_ecm_ctx_t *ue_ecm_ctx, LIBLTE_S1AP_E_RABTOBESETUPITEMCTXTSUREQ_STRUCT *erab_ctxt, struct srslte::gtpc_pdn_address_allocation_ie *paa, srslte::byte_buffer_t *nas_buffer);
   bool pack_identity_request(srslte::byte_buffer_t *reply_msg, uint32_t enb_ue_s1ap_id, uint32_t mme_ue_s1ap_id);
 
   bool pack_emm_information(ue_ctx_t* ue_ctx, srslte::byte_buffer_t *reply_msg);
@@ -116,18 +128,6 @@ public:
   void log_unhandled_attach_request_ies(const LIBLTE_MME_ATTACH_REQUEST_MSG_STRUCT *attach_req);
   void log_unhandled_pdn_con_request_ies(const LIBLTE_MME_PDN_CONNECTIVITY_REQUEST_MSG_STRUCT *pdn_con_req);
   void log_unhandled_initial_ue_message_ies(LIBLTE_S1AP_MESSAGE_INITIALUEMESSAGE_STRUCT *init_ue);
-
-
-private:
-  s1ap_nas_transport();
-  virtual ~s1ap_nas_transport();
-
-  srslte::log *m_s1ap_log;
-  srslte::byte_buffer_pool *m_pool;
-
-  s1ap* m_s1ap;
-  hss_interface_s1ap*  m_hss;
-  mme_gtpc* m_mme_gtpc;
 };
 } //namespace srsepc
 #endif // SRSEPC_S1AP_NAS_TRANSPORT_H

--- a/srsepc/src/mme/s1ap_ctx_mngmt_proc.cc
+++ b/srsepc/src/mme/s1ap_ctx_mngmt_proc.cc
@@ -159,7 +159,7 @@ s1ap_ctx_mngmt_proc::send_initial_context_setup_request(ue_emm_ctx_t *emm_ctx,
   }
   //Get K eNB
   liblte_unpack(emm_ctx->security_ctxt.k_enb, 32, in_ctxt_req->SecurityKey.buffer);
-  m_s1ap_log->info_hex(emm_ctx->security_ctxt.k_enb, 32, "Initial Context Setup Request -- Key eNB\n");
+  m_s1ap_log->info_hex(emm_ctx->security_ctxt.k_enb, 32, "Initial Context Setup Request -- Key eNB (k_enb)\n");
 
   srslte::byte_buffer_t *nas_buffer = m_pool->allocate();
   if(emm_ctx->state == EMM_STATE_DEREGISTERED)

--- a/srsepc/src/mme/s1ap_nas_transport.cc
+++ b/srsepc/src/mme/s1ap_nas_transport.cc
@@ -674,10 +674,11 @@ s1ap_nas_transport::handle_nas_guti_attach_request(  uint32_t enb_ue_s1ap_id,
         m_s1ap->add_ue_ctx_to_mme_ue_s1ap_id_map(ue_ctx);
         
         //Re-generate K_eNB
-        liblte_security_generate_k_enb(emm_ctx->security_ctxt.k_asme, emm_ctx->security_ctxt.ul_nas_count, emm_ctx->security_ctxt.k_enb);
+        srslte::security_generate_k_enb(emm_ctx->security_ctxt.k_asme, emm_ctx->security_ctxt.ul_nas_count, emm_ctx->security_ctxt.k_enb);
         m_s1ap_log->info("Generating KeNB with UL NAS COUNT: %d\n",emm_ctx->security_ctxt.ul_nas_count);
         m_s1ap_log->console("Generating KeNB with UL NAS COUNT: %d\n",emm_ctx->security_ctxt.ul_nas_count);
-        
+        m_s1ap_log->info_hex(emm_ctx->security_ctxt.k_enb, 32, "Key eNodeB (k_enb)\n");
+
         m_s1ap_log->console("Attach request -- IMSI: %015lu\n", ecm_ctx->imsi);
         m_s1ap_log->info("Attach request -- IMSI: %015lu\n", ecm_ctx->imsi);
         m_s1ap_log->console("Attach request -- eNB-UE S1AP Id: %d, MME-UE S1AP Id: %d\n", ecm_ctx->enb_ue_s1ap_id, ecm_ctx->mme_ue_s1ap_id);
@@ -873,8 +874,10 @@ s1ap_nas_transport::handle_nas_service_request(uint32_t m_tmsi,
     m_s1ap_log->console("UE previously assigned IP: %s",inet_ntoa(emm_ctx->ue_ip));
 
     //Re-generate K_eNB
-    liblte_security_generate_k_enb(emm_ctx->security_ctxt.k_asme, emm_ctx->security_ctxt.ul_nas_count, emm_ctx->security_ctxt.k_enb);
+    srslte::security_generate_k_enb(emm_ctx->security_ctxt.k_asme, emm_ctx->security_ctxt.ul_nas_count, emm_ctx->security_ctxt.k_enb);
     m_s1ap_log->info("Generating KeNB with UL NAS COUNT: %d\n",emm_ctx->security_ctxt.ul_nas_count);
+    m_s1ap_log->console("Generating KeNB with UL NAS COUNT: %d\n",emm_ctx->security_ctxt.ul_nas_count);
+    m_s1ap_log->info_hex(emm_ctx->security_ctxt.k_enb, 32, "Key eNodeB (k_enb)\n");
     m_s1ap_log->console("UE Ctr TEID %d\n", emm_ctx->sgw_ctrl_fteid.teid);
 
     //Save UE ctx to MME UE S1AP id
@@ -1617,15 +1620,15 @@ s1ap_nas_transport::pack_security_mode_command(srslte::byte_buffer_t *reply_msg,
                            ue_emm_ctx->security_ctxt.k_nas_enc,
                            ue_emm_ctx->security_ctxt.k_nas_int
                          );
-  srslte::security_generate_k_nas( ue_emm_ctx->security_ctxt.k_asme,
-                                   srslte::CIPHERING_ALGORITHM_ID_EEA0,
-                                   srslte::INTEGRITY_ALGORITHM_ID_128_EIA1,
-                                   ue_emm_ctx->security_ctxt.k_nas_enc,
-                                   ue_emm_ctx->security_ctxt.k_nas_int
-                                   );
+
+  m_s1ap_log->info_hex(ue_emm_ctx->security_ctxt.k_nas_enc, 32, "Key NAS Encryption (k_nas_enc)\n");
+  m_s1ap_log->info_hex(ue_emm_ctx->security_ctxt.k_nas_int, 32, "Key NAS Integrity (k_nas_int)\n");
+
   uint8_t key_enb[32];
-  liblte_security_generate_k_enb(ue_emm_ctx->security_ctxt.k_asme, ue_emm_ctx->security_ctxt.ul_nas_count, ue_emm_ctx->security_ctxt.k_enb);
-  m_s1ap_log->info("Generating KeNB with UL NAS COUNT: %d\n",ue_emm_ctx->security_ctxt.ul_nas_count);
+  srslte::security_generate_k_enb(ue_emm_ctx->security_ctxt.k_asme, ue_emm_ctx->security_ctxt.ul_nas_count, ue_emm_ctx->security_ctxt.k_enb);
+  m_s1ap_log->info("Generating KeNB with UL NAS COUNT: %d\n", ue_emm_ctx->security_ctxt.ul_nas_count);
+  m_s1ap_log->console("Generating KeNB with UL NAS COUNT: %d\n", ue_emm_ctx->security_ctxt.ul_nas_count);
+  m_s1ap_log->info_hex(ue_emm_ctx->security_ctxt.k_enb, 32, "Key eNodeB (k_enb)\n");
   //Generate MAC for integrity protection
   //FIXME Write wrapper to support EIA1, EIA2, etc.
   srslte::security_128_eia1 (&ue_emm_ctx->security_ctxt.k_nas_int[16],

--- a/srsepc/src/mme/s1ap_nas_transport.cc
+++ b/srsepc/src/mme/s1ap_nas_transport.cc
@@ -1032,6 +1032,7 @@ s1ap_nas_transport::handle_nas_authentication_response(srslte::byte_buffer_t *na
     m_s1ap_log->console("UE Authentication Accepted.\n");
     m_s1ap_log->info("UE Authentication Accepted.\n");
     //Send Security Mode Command
+    emm_ctx->security_ctxt.ul_nas_count = 0; // Reset the NAS uplink counter for the right key k_enb derivation
     pack_security_mode_command(reply_buffer, emm_ctx, ecm_ctx);
     *reply_flag = true;
     m_s1ap_log->console("Downlink NAS: Sending NAS Security Mode Command.\n");
@@ -1121,10 +1122,10 @@ s1ap_nas_transport::handle_nas_attach_complete(srslte::byte_buffer_t *nas_msg, u
     //Attach requested from attach request
     m_mme_gtpc->send_modify_bearer_request(emm_ctx->imsi, &ecm_ctx->erabs_ctx[act_bearer.eps_bearer_id]);
     //Send reply to eNB
-    m_s1ap_log->console("Packing EMM infromationi\n");
+    m_s1ap_log->console("Packing EMM Information\n");
     *reply_flag = pack_emm_information(ue_ctx, reply_msg);
-    m_s1ap_log->console("Sending EMM infromation, bytes %d\n",reply_msg->N_bytes);
-    m_s1ap_log->info("Sending EMM infromation\n");
+    m_s1ap_log->console("Sending EMM Information, bytes %d\n",reply_msg->N_bytes);
+    m_s1ap_log->info("Sending EMM Information\n");
   }
   emm_ctx->state = EMM_STATE_REGISTERED;
   return true;
@@ -1181,8 +1182,8 @@ s1ap_nas_transport::handle_identity_response(srslte::byte_buffer_t *nas_msg, ue_
   ue_emm_ctx_t *emm_ctx = &ue_ctx->emm_ctx;
   ue_ecm_ctx_t *ecm_ctx = &ue_ctx->ecm_ctx;
 
-  m_s1ap_log->info("Id Response -- IMSI: %015lu\n", imsi);
-  m_s1ap_log->console("Id Response -- IMSI: %015lu\n", imsi);
+  m_s1ap_log->info("ID response -- IMSI: %015lu\n", imsi);
+  m_s1ap_log->console("ID Response -- IMSI: %015lu\n", imsi);
 
   //Set UE's context IMSI
   emm_ctx->imsi=imsi;


### PR DESCRIPTION
This branch solves problems wrong key eNodeB derivation, I encountered when the TMSI is not known. See more on the mailing list "RRC Security Mode Command Failure".