### PR TITLE
Initial ctxt failure problem

### DIFF
--- a/srsenb/src/upper/s1ap.cc
+++ b/srsenb/src/upper/s1ap.cc
@@ -962,7 +962,6 @@ bool s1ap::send_initial_ctxt_setup_failure(uint16_t rnti)
   fail->Cause.choice.radioNetwork.ext = false;
   fail->Cause.choice.radioNetwork.e   = LIBLTE_S1AP_CAUSERADIONETWORK_UNSPECIFIED;
 
-  //liblte_s1ap_pack_s1ap_pdu(&tx_pdu, (LIBLTE_BYTE_MSG_STRUCT*)&buf);
   liblte_s1ap_pack_s1ap_pdu(&tx_pdu, (LIBLTE_BYTE_MSG_STRUCT*)buf);
   s1ap_log->info_hex(buf->msg, buf->N_bytes, "Sending InitialContextSetupFailure for RNTI:0x%x", rnti);
 

--- a/srsenb/src/upper/s1ap.cc
+++ b/srsenb/src/upper/s1ap.cc
@@ -962,7 +962,8 @@ bool s1ap::send_initial_ctxt_setup_failure(uint16_t rnti)
   fail->Cause.choice.radioNetwork.ext = false;
   fail->Cause.choice.radioNetwork.e   = LIBLTE_S1AP_CAUSERADIONETWORK_UNSPECIFIED;
 
-  liblte_s1ap_pack_s1ap_pdu(&tx_pdu, (LIBLTE_BYTE_MSG_STRUCT*)&buf);
+  //liblte_s1ap_pack_s1ap_pdu(&tx_pdu, (LIBLTE_BYTE_MSG_STRUCT*)&buf);
+  liblte_s1ap_pack_s1ap_pdu(&tx_pdu, (LIBLTE_BYTE_MSG_STRUCT*)buf);
   s1ap_log->info_hex(buf->msg, buf->N_bytes, "Sending InitialContextSetupFailure for RNTI:0x%x", rnti);
 
   ssize_t n_sent = sctp_sendmsg(socket_fd, buf->msg, buf->N_bytes,


### PR DESCRIPTION
I was trying to send an Initial Ctxt Setup Failure to the MME and the eNB was crashing every time I sent the msg. 
The problem was the call of the liblte_s1ap_pack_s1ap_pdu. 
I have done several tests with 2 UEs and is working properly. 

Greetings,
Katerina