### PR TITLE
add keys to loglevel 'info' to simplify PCAP analysis

### DIFF
--- a/srsue/src/upper/nas.cc
+++ b/srsue/src/upper/nas.cc
@@ -757,7 +757,7 @@ void nas::parse_authentication_request(uint32_t lcid, byte_buffer_t *pdu) {
   if (auth_result == AUTH_OK) {
     nas_log->info("Network authentication successful\n");
     send_authentication_response(res, res_len);
-    nas_log->info("Generated k_asme=%s\n", hex_to_string(ctxt.k_asme, 32).c_str());
+    nas_log->info_hex(ctxt.k_asme, 32, "Generated k_asme:\n");
   } else if (auth_result == AUTH_SYNCH_FAILURE) {
     nas_log->error("Network authentication synchronization failure.\n");
     send_authentication_failure(LIBLTE_MME_EMM_CAUSE_SYNCH_FAILURE, res);
@@ -878,8 +878,8 @@ void nas::parse_security_mode_command(uint32_t lcid, byte_buffer_t *pdu)
   // Generate NAS keys
   usim->generate_nas_keys(ctxt.k_asme, k_nas_enc, k_nas_int,
                           ctxt.cipher_algo, ctxt.integ_algo);
-  nas_log->debug_hex(k_nas_enc, 32, "NAS encryption key - k_nas_enc");
-  nas_log->debug_hex(k_nas_int, 32, "NAS integrity key - k_nas_int");
+  nas_log->info_hex(k_nas_enc, 32, "NAS encryption key - k_nas_enc");
+  nas_log->info_hex(k_nas_int, 32, "NAS integrity key - k_nas_int");
 
   nas_log->debug("Generating integrity check. integ_algo:%d, count_dl:%d, lcid:%d\n",
                  ctxt.integ_algo, ctxt.rx_count, lcid);

--- a/srsue/src/upper/pcsc_usim.cc
+++ b/srsue/src/upper/pcsc_usim.cc
@@ -250,7 +250,7 @@ auth_result_t pcsc_usim::generate_authentication_response(uint8_t  *rand,
                             mcc,
                             mnc,
                             k_asme);
-  log->debug_hex(k_asme, KEY_LEN, "K_ASME:\n");
+  log->info_hex(k_asme, KEY_LEN, "K_ASME:\n");
 
   ret = AUTH_OK;
 

--- a/srsue/src/upper/rrc.cc
+++ b/srsue/src/upper/rrc.cc
@@ -2036,9 +2036,9 @@ void rrc::parse_dl_dcch(uint32_t lcid, byte_buffer_t *pdu) {
       uint8_t k_asme[32];
       nas->get_k_asme(k_asme, 32);
       usim->generate_as_keys(k_asme, nas->get_ul_count(), k_rrc_enc, k_rrc_int, k_up_enc, k_up_int, cipher_algo, integ_algo);
-      rrc_log->debug_hex(k_rrc_enc, 32, "RRC encryption key - k_rrc_enc");
-      rrc_log->debug_hex(k_rrc_int, 32, "RRC integrity key  - k_rrc_int");
-      rrc_log->debug_hex(k_up_enc, 32,  "UP encryption key  - k_up_enc");
+      rrc_log->info_hex(k_rrc_enc, 32, "RRC encryption key - k_rrc_enc");
+      rrc_log->info_hex(k_rrc_int, 32, "RRC integrity key  - k_rrc_int");
+      rrc_log->info_hex(k_up_enc, 32,  "UP encryption key  - k_up_enc");
 
       security_is_activated = true;
 


### PR DESCRIPTION
Access to the keys allows easy analysis of PCAPs.