### PR TITLE
gtp parses optional fields in gtpu_read_header (and ignores seqnum later on)

### DIFF
--- a/lib/include/srslte/upper/gtpu.h
+++ b/lib/include/srslte/upper/gtpu.h
@@ -56,6 +56,9 @@ typedef struct{
   uint8_t   message_type;   // Only support 0xFF - T-PDU type
   uint16_t  length;
   uint32_t  teid;
+  uint16_t  seqnum;
+  uint8_t   npdu_num;
+  uint8_t   nxt_head_type;
 }gtpu_header_t;
 
 

--- a/srsepc/src/spgw/spgw.cc
+++ b/srsepc/src/spgw/spgw.cc
@@ -393,15 +393,16 @@ spgw::handle_sgi_pdu(srslte::byte_buffer_t *msg)
 void
 spgw::handle_s1u_pdu(srslte::byte_buffer_t *msg)
 {
-  //m_spgw_log->console("Received PDU from S1-U. Bytes=%d\n",msg->N_bytes);
+  m_spgw_log->console("Received PDU from S1-U. Bytes=%d\n",msg->N_bytes);
   srslte::gtpu_header_t header;
   srslte::gtpu_read_header(msg, &header, m_spgw_log);
  
-  //m_spgw_log->console("TEID 0x%x. Bytes=%d\n", header.teid, msg->N_bytes);
-  int n = write(m_sgi_if, msg->msg, msg->N_bytes);
+  m_spgw_log->console("TEID 0x%x. Bytes=%d\n", header.teid, msg->N_bytes);
+  ssize_t n = write(m_sgi_if, msg->msg, msg->N_bytes);
   if(n<0)
   {
     m_spgw_log->error("Could not write to TUN interface.\n");
+    m_spgw_log->error("Error code %ld %s\n", n, strerror(errno));
   }
   else
   {


### PR DESCRIPTION
Problem: our eNB sets GTPU header flag 0x32, but this is rejected by srsepc. Solution:
- added fields to gtpu_header_t
- gtpu_read_header now parses the sequence number and stores it in the header (and then ignores it in the rest of the code)
- spgw.cc line 401 changed return value to type ssize_t. Initially the write syscall to the tun interface was failing because the pdu was not parsed correctly, causing a IP mismatch. The code in gtpu_read_header fixes that - no changes are needed to spgw.cc. 
- these fixes get srsepc to work with our eNB. UE is able to access the net and ping pgw. 