### PR TITLE
Lock pthread mutex at initialization

### DIFF
--- a/srsenb/src/phy/phch_common.cc
+++ b/srsenb/src/phy/phch_common.cc
@@ -63,6 +63,9 @@ bool phch_common::init(srslte_cell_t *cell_, srslte::radio* radio_h_, mac_interf
   is_first_tx = true; 
   for (uint32_t i=0;i<max_mutex;i++) {
     pthread_mutex_init(&tx_mutex[i], NULL);
+    if (i>0){
+      pthread_mutex_lock(&tx_mutex[i]);
+    }
   }
   reset(); 
   return true; 


### PR DESCRIPTION
The phch_common::init function returns with all mutex unlocked as the
initial state. It allows multiple threads to transmit at the same time
at the begining. It causes BladeRF TX error described in issue #180 and #142.

This patch fixes this bug by locking all the mutex in the init function
except the first mutex.