### PR TITLE
Set AMF to all zeros during resync

### DIFF
--- a/srsepc/src/hss/hss.cc
+++ b/srsepc/src/hss/hss.cc
@@ -594,6 +594,10 @@ hss::resync_sqn_milenage(uint64_t imsi, uint8_t *auts)
 
   uint8_t mac_s_tmp[8];
 
+  for(int i=0; i<2; i++){
+    amf[i] = 0;
+  }
+
   security_milenage_f1_star(k, opc, last_rand, sqn_ms, amf, mac_s_tmp);
 
   m_hss_log->debug_hex(mac_s_tmp, 8, "MAC calc : ");


### PR DESCRIPTION
During the resync procedure, the security_milenage_f1_star generates a
MAC_S value that does not match the MAC_S value reported in AUTS. This
posts a security risk.

According to 3GPP TS 33.102 version 11.5.1 section 6.3.3, the AMF used
to calculate MAC-S assumes a dummy value of all zeros so that it does
not need to be transmitted in the clear in the re-synch message.

This patch corrects this problem. MAC_S reported by AUTS matches the
MAC_S calculated using f1_star function after the fix.