### PR TITLE
Drfort patch 1

### DIFF
--- a/lib/include/srslte/phy/ue/ue_cell_search.h
+++ b/lib/include/srslte/phy/ue/ue_cell_search.h
@@ -102,6 +102,11 @@ SRSLTE_API int srslte_ue_cellsearch_scan(srslte_ue_cellsearch_t * q,
                                          srslte_ue_cellsearch_result_t found_cells[3], 
                                          uint32_t *max_N_id_2); 
 
+SRSLTE_API int srslte_ue_cellsearch_scan_cell_id(srslte_ue_cellsearch_t * q,
+                                                 int32_t search_cell_id,
+                                                 srslte_ue_cellsearch_result_t found_cells[3],
+                                                 uint32_t *max_N_id_2);
+
 SRSLTE_API int srslte_ue_cellsearch_set_nof_valid_frames(srslte_ue_cellsearch_t *q, 
                                                          uint32_t nof_frames);
 

--- a/lib/src/phy/ue/ue_cell_search.c
+++ b/lib/src/phy/ue/ue_cell_search.c
@@ -271,6 +271,35 @@ int srslte_ue_cellsearch_scan(srslte_ue_cellsearch_t * q,
   return nof_detected_cells;
 }
 
+/** Finds up to 3 cells, one per each N_id_2=0,1,2 and stores ID and CP in the structure pointed by found_cell.
+ * Each position in found_cell corresponds to a different N_id_2.
+ * Saves in the pointer max_N_id_2 the N_id_2 index of the cell with the matching cell ID
+ * Returns the number of found cells or a negative number if error
+ */
+int srslte_ue_cellsearch_scan_cell_id(srslte_ue_cellsearch_t * q,
+                                      int32_t search_cell_id,
+                                      srslte_ue_cellsearch_result_t found_cells[3],
+                                      uint32_t *max_N_id_2)
+{
+  int ret = 0;
+  uint32_t nof_detected_cells = 0;
+  for (uint32_t N_id_2=0;N_id_2<3 && ret >= 0;N_id_2++) {
+    ret = srslte_ue_cellsearch_scan_N_id_2(q, N_id_2, &found_cells[N_id_2]);
+    if (ret < 0) {
+      fprintf(stderr, "Error searching cell\n");
+      return ret;
+    }
+    if (max_N_id_2) {
+      if (found_cells[N_id_2].cell_id == search_cell_id) {
+        *max_N_id_2 = N_id_2;
+        nof_detected_cells += ret;
+        break;
+      }
+    }
+  }
+  return nof_detected_cells;
+}
+
 /** Finds a cell for a given N_id_2 and stores ID and CP in the structure pointed by found_cell. 
  * Returns 1 if the cell is found, 0 if not or -1 on error
  */

--- a/srsue/hdr/phy/phch_recv.h
+++ b/srsue/hdr/phy/phch_recv.h
@@ -80,6 +80,7 @@ public:
   // From UE configuration
   void    set_agc_enable(bool enable);
   void    set_earfcn(std::vector<uint32_t> earfcn);
+  void    set_search_phy_cell_id(int32_t search_phy_cell_id);
   void    force_freq(float dl_freq, float ul_freq);
 
   // Other functions
@@ -100,6 +101,7 @@ private:
     void     reset();
     float    get_last_cfo();
     void     set_agc_enable(bool enable);
+    void     set_search_phy_cell_id(int32_t search_phy_cell_id);
     ret_code run(srslte_cell_t *cell);
 
   private:
@@ -109,6 +111,7 @@ private:
     srslte_ue_cellsearch_t  cs;
     srslte_ue_mib_sync_t    ue_mib_sync;
     int                     force_N_id_2;
+    int32_t                 search_phy_cell_id;
   };
 
   // Class to synchronize system frame number

--- a/srsue/hdr/phy/phy.h
+++ b/srsue/hdr/phy/phy.h
@@ -76,6 +76,7 @@ public:
   void write_trace(std::string filename);
 
   void set_earfcn(std::vector<uint32_t> earfcns);
+  void set_search_phy_cell_id(int32_t cell_id);
   void force_freq(float dl_freq, float ul_freq);
 
   void radio_overflow();

--- a/srsue/hdr/ue_base.h
+++ b/srsue/hdr/ue_base.h
@@ -55,6 +55,7 @@ namespace srsue {
 
 typedef struct {
   uint32_t      dl_earfcn;
+  int32_t       phy_cell_id;
   float         dl_freq;
   float         ul_freq;
   float         freq_offset;

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -66,6 +66,7 @@ void parse_args(all_args_t *args, int argc, char *argv[]) {
   bpo::options_description common("Configuration options");
   common.add_options()
     ("rf.dl_earfcn", bpo::value<uint32_t>(&args->rf.dl_earfcn)->default_value(3400), "Downlink EARFCN")
+    ("rf.phy_cell_id", bpo::value<int32_t>(&args->rf.phy_cell_id)->default_value(-1), "Physical cell ID")
     ("rf.freq_offset", bpo::value<float>(&args->rf.freq_offset)->default_value(0), "(optional) Frequency offset")
     ("rf.dl_freq",     bpo::value<float>(&args->rf.dl_freq)->default_value(-1),      "Downlink Frequency (if positive overrides EARFCN)")
     ("rf.ul_freq",     bpo::value<float>(&args->rf.ul_freq)->default_value(-1),      "Uplink Frequency (if positive overrides EARFCN)")

--- a/srsue/src/phy/phch_recv.cc
+++ b/srsue/src/phy/phch_recv.cc
@@ -745,6 +745,11 @@ void phch_recv::set_earfcn(std::vector<uint32_t> earfcn) {
   this->earfcn = earfcn;
 }
 
+void phch_recv::set_search_phy_cell_id(int32_t search_phy_cell_id)
+{
+  search_p.set_search_phy_cell_id(search_phy_cell_id);
+}
+
 void phch_recv::force_freq(float dl_freq, float ul_freq) {
   this->dl_freq = dl_freq;
   this->ul_freq = ul_freq;
@@ -884,6 +889,7 @@ void phch_recv::search::init(cf_t *buffer[SRSLTE_MAX_PORTS], srslte::log *log_h,
   p->set_ue_sync_opts(&cs.ue_sync, 0);
 
   force_N_id_2 = -1;
+  search_phy_cell_id = -1;
 }
 
 void phch_recv::search::reset()
@@ -907,6 +913,11 @@ void phch_recv::search::set_agc_enable(bool enable) {
   } else {
     fprintf(stderr, "Error stop AGC not implemented\n");
   }
+}
+
+void phch_recv::search::set_search_phy_cell_id(int32_t search_phy_cell_id)
+{
+  this->search_phy_cell_id = search_phy_cell_id;
 }
 
 phch_recv::search::ret_code phch_recv::search::run(srslte_cell_t *cell)
@@ -940,6 +951,8 @@ phch_recv::search::ret_code phch_recv::search::run(srslte_cell_t *cell)
   if (force_N_id_2 >= 0 && force_N_id_2 < 3) {
     ret = srslte_ue_cellsearch_scan_N_id_2(&cs, force_N_id_2, &found_cells[force_N_id_2]);
     max_peak_cell = force_N_id_2;
+  } else if ((search_phy_cell_id >= 0) && (search_phy_cell_id <= 503)) {
+    ret = srslte_ue_cellsearch_scan_cell_id(&cs, search_phy_cell_id, found_cells, &max_peak_cell);
   } else {
     ret = srslte_ue_cellsearch_scan(&cs, found_cells, &max_peak_cell);
   }

--- a/srsue/src/phy/phy.cc
+++ b/srsue/src/phy/phy.cc
@@ -383,6 +383,11 @@ void phy::set_earfcn(vector< uint32_t > earfcns)
   sf_recv.set_earfcn(earfcns);
 }
 
+void phy::set_search_phy_cell_id(int32_t cell_id)
+{
+  sf_recv.set_search_phy_cell_id(cell_id);
+}
+
 void phy::force_freq(float dl_freq, float ul_freq)
 {
   sf_recv.force_freq(dl_freq, ul_freq);

--- a/srsue/src/ue.cc
+++ b/srsue/src/ue.cc
@@ -239,6 +239,8 @@ bool ue::init(all_args_t *args_) {
   earfcn_list.push_back(args->rf.dl_earfcn);
   phy.set_earfcn(earfcn_list);
 
+  phy.set_search_phy_cell_id(args->rf.phy_cell_id);
+
   if (args->rf.dl_freq > 0 && args->rf.ul_freq > 0) {
     phy.force_freq(args->rf.dl_freq, args->rf.ul_freq);
   }

--- a/srsue/ue.conf.example
+++ b/srsue/ue.conf.example
@@ -9,6 +9,7 @@
 # rx_gain: Optional receive gain (dB). If disabled, AGC if enabled
 #
 # Optional parameters: 
+# phy_cell_id         Physical Cell ID
 # dl_freq:            Override DL frequency corresponding to dl_earfcn
 # ul_freq:            Override UL frequency corresponding to dl_earfcn
 # nof_rx_ant:         Number of RX antennas (Default 1, supported 1 or 2)


### PR DESCRIPTION
This patch adds support for searching for a particular cell with the matching PCI (Physical Cell ID).  This can be useful when there are more than one cell with the same EARFCN and we are only interested in a particular cell with the known PCI for testing.   The patch allows you to specify the PCI via the ue.conf file or as one of the arguments on the command line (--rf.phy_cell_id).