### PR TITLE
Live MAC Layer Trace in UDP Framing 

### DIFF
--- a/lib/include/srslte/common/live_mac_trace.h
+++ b/lib/include/srslte/common/live_mac_trace.h
@@ -1,0 +1,72 @@
+/**
+ *
+ * \section COPYRIGHT
+ *
+ * Copyright 2013-2018 Software Radio Systems Limited
+ *
+ * \section LICENSE
+ *
+ * This file is part of the srsUE library.
+ *
+ * srsUE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsUE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+
+#ifndef SRSLTE_LIVE_MAC_TRACE_H
+#define SRSLTE_LIVE_MAC_TRACE_H
+
+
+#include "srslte/common/pcap.h"
+#include "srslte/srslte.h"
+#include "srslte/common/threads.h"
+
+#define MAC_UDP_PDU_MAX_SIZE 1600
+
+namespace srslte {
+
+class live_mac_trace {
+public:
+  live_mac_trace();
+  void init(char * server_ip_addr_, uint16_t server_udp_port_, char * client_ip_addr_, uint16_t client_udp_port_);
+  void stop();
+  void set_ue_id(uint16_t ue_id);
+
+  void write_ul_crnti(uint8_t *pdu, uint32_t pdu_len_bytes, uint16_t crnti, uint32_t reTX, uint32_t tti);
+  void write_dl_crnti(uint8_t *pdu, uint32_t pdu_len_bytes, uint16_t crnti, bool crc_ok, uint32_t tti);
+  void write_dl_ranti(uint8_t *pdu, uint32_t pdu_len_bytes, uint16_t ranti, bool crc_ok, uint32_t tti);
+  
+  // SI and BCH only for DL 
+  void write_dl_sirnti(uint8_t *pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti);
+  void write_dl_bch(uint8_t *pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti);
+  void write_dl_pch(uint8_t *pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti);
+  void write_dl_mch(uint8_t *pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti);
+
+private:
+  uint16_t ueid;
+  uint16_t udp_port;
+  uint8_t buffer[MAC_UDP_PDU_MAX_SIZE];
+
+  struct sockaddr_in server_addr;
+  struct sockaddr_in client_addr;
+
+  int socket_d;
+  void send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, uint32_t reTX, bool crc_ok, uint32_t tti,
+                              uint16_t crnti_, uint8_t direction, uint8_t rnti_type);
+};
+
+}
+
+#endif // SRSLTE_LIVE_MAC_TRACE_H

--- a/lib/include/srslte/common/live_mac_trace.h
+++ b/lib/include/srslte/common/live_mac_trace.h
@@ -40,7 +40,7 @@ namespace srslte {
 class live_mac_trace {
 public:
   live_mac_trace();
-  void init(char * server_ip_addr_, uint16_t server_udp_port_, char * client_ip_addr_, uint16_t client_udp_port_);
+  void init(const char * server_ip_addr_, uint16_t server_udp_port_, const char * client_ip_addr_, uint16_t client_udp_port_);
   void stop();
   void set_ue_id(uint16_t ue_id);
 

--- a/lib/include/srslte/common/live_mac_trace.h
+++ b/lib/include/srslte/common/live_mac_trace.h
@@ -32,12 +32,12 @@
 #include "srslte/common/pcap.h"
 #include "srslte/srslte.h"
 #include "srslte/common/threads.h"
-
-#define MAC_UDP_PDU_MAX_SIZE 1600
+#include "srslte/common/buffer_pool.h"
+#include "srslte/common/block_queue.h"
 
 namespace srslte {
 
-class live_mac_trace {
+class live_mac_trace : thread{
 public:
   live_mac_trace();
   void init(const char * server_ip_addr_, uint16_t server_udp_port_, const char * client_ip_addr_, uint16_t client_udp_port_);
@@ -55,16 +55,28 @@ public:
   void write_dl_mch(uint8_t *pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti);
 
 private:
+  byte_buffer_pool        *pool;
+  bool running;
+  byte_buffer_t udp_datagram;
+
   uint16_t ueid;
   uint16_t udp_port;
-  uint8_t buffer[MAC_UDP_PDU_MAX_SIZE];
+
+  typedef struct{
+    MAC_Context_Info_t  context;
+    srslte::byte_buffer_t*  pdu;
+  }mac_trace_pdu_t;
+
+  srslte::block_queue<mac_trace_pdu_t> mac_trace_pdu_queue;
 
   struct sockaddr_in server_addr;
   struct sockaddr_in client_addr;
 
   int socket_d;
-  void send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, uint32_t reTX, bool crc_ok, uint32_t tti,
+  void pack_and_queue(uint8_t* pdu, uint32_t pdu_len_bytes, uint32_t reTX, bool crc_ok, uint32_t tti,
                               uint16_t crnti_, uint8_t direction, uint8_t rnti_type);
+  void send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, MAC_Context_Info_t *context);
+  void run_thread();
 };
 
 }

--- a/lib/src/common/live_mac_trace.cc
+++ b/lib/src/common/live_mac_trace.cc
@@ -1,0 +1,166 @@
+/**
+ *
+ * \section COPYRIGHT
+ *
+ * Copyright 2013-2018 Software Radio Systems Limited
+ *
+ * \section LICENSE
+ *
+ * This file is part of the srsUE library.
+ *
+ * srsUE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsUE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#include "srslte/common/live_mac_trace.h"
+
+using namespace std;
+
+namespace srslte{
+  
+live_mac_trace::live_mac_trace(){
+
+}
+
+void live_mac_trace::init(char * server_ip_addr_, uint16_t server_udp_port_, char * client_ip_addr_, uint16_t client_udp_port_){
+  ueid = 0;
+  socket_d = -1;
+  socket_d = socket(AF_INET, SOCK_DGRAM, 0);
+  if(socket_d < 0) {
+    printf("Failed to create listener socket: %s\n", strerror(errno));
+    return;
+  }
+
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_addr.s_addr = inet_addr(server_ip_addr_);
+  server_addr.sin_port = htons(server_udp_port_);
+  
+  int ret = bind(socket_d, (struct sockaddr *) &server_addr, sizeof(server_addr));
+  
+  if (ret != 0){
+    printf("Failed to bind socket to (%s:%u) %s\n", server_ip_addr_, server_udp_port_, strerror(errno));
+    close(socket_d);
+    socket_d = -1;
+  } 
+
+  client_addr.sin_family = AF_INET;
+  client_addr.sin_addr.s_addr = inet_addr(client_ip_addr_);
+  client_addr.sin_port = htons(client_udp_port_);
+}
+
+void live_mac_trace::stop(){
+  close(socket_d);
+
+}
+
+void live_mac_trace::write_dl_crnti(uint8_t* pdu, uint32_t pdu_len_bytes, uint16_t rnti, bool crc_ok, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, rnti, DIRECTION_DOWNLINK, C_RNTI);
+}
+void live_mac_trace::write_dl_ranti(uint8_t* pdu, uint32_t pdu_len_bytes, uint16_t rnti, bool crc_ok, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, rnti, DIRECTION_DOWNLINK, RA_RNTI);
+}
+void live_mac_trace::write_ul_crnti(uint8_t* pdu, uint32_t pdu_len_bytes, uint16_t rnti, uint32_t reTX, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, reTX, true, tti, rnti, DIRECTION_UPLINK, C_RNTI);
+}
+void live_mac_trace::write_dl_bch(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, 0, DIRECTION_DOWNLINK, NO_RNTI);
+}
+void live_mac_trace::write_dl_pch(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_PRNTI, DIRECTION_DOWNLINK, P_RNTI);
+}
+void live_mac_trace::write_dl_mch(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_MRNTI, DIRECTION_DOWNLINK, M_RNTI);
+}
+void live_mac_trace::write_dl_sirnti(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
+{
+  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_SIRNTI, DIRECTION_DOWNLINK, SI_RNTI);
+}
+
+void live_mac_trace::send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, uint32_t reTX, bool crc_ok, uint32_t tti,
+                              uint16_t rnti, uint8_t direction, uint8_t rnti_type){
+
+  ssize_t bytes_sent;
+  uint32_t offset = 0;
+  uint16_t tmp16;
+
+  uint32_t total_size = pdu_len_bytes + sizeof(MAC_Context_Info_t) + sizeof(MAC_LTE_START_STRING);
+  
+  if (total_size >= MAC_UDP_PDU_MAX_SIZE){
+    printf("PDU size exceeds allocated byte buffer\n");
+    return;
+  }
+   
+  memset(buffer, 0, total_size);
+
+  // MAC_LTE_START_STRING for UDP heuristics 
+  memcpy(buffer + offset, MAC_LTE_START_STRING, strlen(MAC_LTE_START_STRING));
+  offset += strlen(MAC_LTE_START_STRING);
+  
+  /*****************************************************************/
+  /* Context information (same as written by UDP heuristic clients */
+  buffer[offset++] = FDD_RADIO;
+  buffer[offset++] = direction;
+  buffer[offset++] = rnti_type;
+
+  /* RNTI */
+  buffer[offset++] = MAC_LTE_RNTI_TAG;
+  tmp16 = htons(rnti);
+  memcpy(buffer + offset, &tmp16, 2);
+  offset += 2;
+
+  /* UEId */
+  buffer[offset++] = MAC_LTE_UEID_TAG;
+  tmp16 = htons(ueid);
+  memcpy(buffer + offset, &tmp16, 2);
+  offset += 2;
+
+  /* Subframe Number and System Frame Number */
+  /* SFN is stored in 12 MSB and SF in 4 LSB */
+  buffer[offset++] = MAC_LTE_FRAME_SUBFRAME_TAG;
+  tmp16 = (((uint16_t)(tti/10)) << 4) | (uint16_t)(tti%10);
+  tmp16 = htons(tmp16);
+  memcpy(buffer + offset, &tmp16, 2);
+  offset += 2;
+
+  /* CRC Status */
+  buffer[offset++] = MAC_LTE_CRC_STATUS_TAG;
+  buffer[offset++] = crc_ok;
+
+  /* Data tag immediately preceding PDU */
+  buffer[offset++] = MAC_LTE_PAYLOAD_TAG;
+
+  /* Write PDU data into buffer */
+  if (pdu != NULL) {
+    memcpy(buffer + offset, (void*)pdu, pdu_len_bytes);
+    offset += pdu_len_bytes;
+  }
+  // Remote IP 
+  bytes_sent = sendto(socket_d, buffer, offset, 0, (const struct sockaddr *) &client_addr, sizeof(client_addr));
+
+  if (bytes_sent != offset) {
+    printf("Failed to sent MAC UDP Frame (expected %d bytes, sent %d, (errno %d))\n", offset, bytes_sent, errno);
+  }
+
+}
+
+}
+
+

--- a/lib/src/common/live_mac_trace.cc
+++ b/lib/src/common/live_mac_trace.cc
@@ -34,7 +34,7 @@ live_mac_trace::live_mac_trace(){
 
 }
 
-void live_mac_trace::init(char * server_ip_addr_, uint16_t server_udp_port_, char * client_ip_addr_, uint16_t client_udp_port_){
+void live_mac_trace::init(const char * server_ip_addr_, uint16_t server_udp_port_, const char * client_ip_addr_, uint16_t client_udp_port_){
   ueid = 0;
   socket_d = -1;
   socket_d = socket(AF_INET, SOCK_DGRAM, 0);

--- a/lib/src/common/live_mac_trace.cc
+++ b/lib/src/common/live_mac_trace.cc
@@ -31,7 +31,7 @@ using namespace std;
 namespace srslte{
   
 live_mac_trace::live_mac_trace(){
-
+  pool = byte_buffer_pool::get_instance();
 }
 
 void live_mac_trace::init(const char * server_ip_addr_, uint16_t server_udp_port_, const char * client_ip_addr_, uint16_t client_udp_port_){
@@ -58,109 +58,150 @@ void live_mac_trace::init(const char * server_ip_addr_, uint16_t server_udp_port
   client_addr.sin_family = AF_INET;
   client_addr.sin_addr.s_addr = inet_addr(client_ip_addr_);
   client_addr.sin_port = htons(client_udp_port_);
+  mac_trace_pdu_queue.clear();
+  start();
+}
+
+void live_mac_trace::run_thread(){
+  running = true;
+ 
+  while(running){
+    mac_trace_pdu_t mac_trace_pdu = mac_trace_pdu_queue.wait_pop();
+    if(mac_trace_pdu.pdu != NULL){
+      send_mac_datagram(mac_trace_pdu.pdu->msg, mac_trace_pdu.pdu->N_bytes, &mac_trace_pdu.context);
+      pool->deallocate(mac_trace_pdu.pdu);
+    }
+  }
 }
 
 void live_mac_trace::stop(){
+  running = false;
+  mac_trace_pdu_t mac_trace_pdu;
+  mac_trace_pdu.pdu = NULL;
+  mac_trace_pdu_queue.push(mac_trace_pdu);
+  sleep(0.01); // not sexy 
+  wait_thread_finish();
   close(socket_d);
-
 }
 
 void live_mac_trace::write_dl_crnti(uint8_t* pdu, uint32_t pdu_len_bytes, uint16_t rnti, bool crc_ok, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, rnti, DIRECTION_DOWNLINK, C_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, 0, crc_ok, tti, rnti, DIRECTION_DOWNLINK, C_RNTI);
 }
 void live_mac_trace::write_dl_ranti(uint8_t* pdu, uint32_t pdu_len_bytes, uint16_t rnti, bool crc_ok, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, rnti, DIRECTION_DOWNLINK, RA_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, 0, crc_ok, tti, rnti, DIRECTION_DOWNLINK, RA_RNTI);
 }
 void live_mac_trace::write_ul_crnti(uint8_t* pdu, uint32_t pdu_len_bytes, uint16_t rnti, uint32_t reTX, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, reTX, true, tti, rnti, DIRECTION_UPLINK, C_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, reTX, true, tti, rnti, DIRECTION_UPLINK, C_RNTI);
 }
 void live_mac_trace::write_dl_bch(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, 0, DIRECTION_DOWNLINK, NO_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, 0, crc_ok, tti, 0, DIRECTION_DOWNLINK, NO_RNTI);
 }
 void live_mac_trace::write_dl_pch(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_PRNTI, DIRECTION_DOWNLINK, P_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_PRNTI, DIRECTION_DOWNLINK, P_RNTI);
 }
 void live_mac_trace::write_dl_mch(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_MRNTI, DIRECTION_DOWNLINK, M_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_MRNTI, DIRECTION_DOWNLINK, M_RNTI);
 }
 void live_mac_trace::write_dl_sirnti(uint8_t* pdu, uint32_t pdu_len_bytes, bool crc_ok, uint32_t tti)
 {
-  send_mac_datagram(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_SIRNTI, DIRECTION_DOWNLINK, SI_RNTI);
+  pack_and_queue(pdu, pdu_len_bytes, 0, crc_ok, tti, SRSLTE_SIRNTI, DIRECTION_DOWNLINK, SI_RNTI);
 }
 
-void live_mac_trace::send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, uint32_t reTX, bool crc_ok, uint32_t tti,
+void live_mac_trace::pack_and_queue(uint8_t* pdu, uint32_t pdu_len_bytes, uint32_t reTX, bool crc_ok, uint32_t tti,
                               uint16_t rnti, uint8_t direction, uint8_t rnti_type){
+  byte_buffer_t*  udp_pdu;
+  mac_trace_pdu_t mac_trace_pdu;
+  
+  udp_pdu = pool->allocate();
+
+  memcpy(udp_pdu->msg, pdu, pdu_len_bytes);
+  udp_pdu->N_bytes = pdu_len_bytes;
+
+  mac_trace_pdu.pdu = udp_pdu;
+
+  mac_trace_pdu.context.radioType = FDD_RADIO;
+  mac_trace_pdu.context.direction = direction;
+  mac_trace_pdu.context.rntiType = rnti_type;
+  mac_trace_pdu.context.rnti = rnti;
+  mac_trace_pdu.context.ueid = ueid;
+  mac_trace_pdu.context.isRetx = reTX;
+  mac_trace_pdu.context.crcStatusOK = crc_ok;
+  mac_trace_pdu.context.sysFrameNumber = (uint16_t)(tti/10);
+  mac_trace_pdu.context.subFrameNumber = (uint16_t)(tti%10);
+  mac_trace_pdu_queue.push(mac_trace_pdu);
+}
+
+void live_mac_trace::send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, MAC_Context_Info_t *context){
 
   ssize_t bytes_sent;
   uint32_t offset = 0;
   uint16_t tmp16;
-
+  
   uint32_t total_size = pdu_len_bytes + sizeof(MAC_Context_Info_t) + sizeof(MAC_LTE_START_STRING);
   
-  if (total_size >= MAC_UDP_PDU_MAX_SIZE){
-    printf("PDU size exceeds allocated byte buffer\n");
+  if( SRSLTE_MAX_BUFFER_SIZE_BYTES <= total_size){
+    printf("Send length does exceed max buffer length\n");
     return;
   }
-   
-  memset(buffer, 0, total_size);
 
   // MAC_LTE_START_STRING for UDP heuristics 
-  memcpy(buffer + offset, MAC_LTE_START_STRING, strlen(MAC_LTE_START_STRING));
+  memcpy(udp_datagram.msg + offset, MAC_LTE_START_STRING, strlen(MAC_LTE_START_STRING));
   offset += strlen(MAC_LTE_START_STRING);
   
   /*****************************************************************/
   /* Context information (same as written by UDP heuristic clients */
-  buffer[offset++] = FDD_RADIO;
-  buffer[offset++] = direction;
-  buffer[offset++] = rnti_type;
+  udp_datagram.msg[offset++] = context->radioType;
+  udp_datagram.msg[offset++] = context->direction;
+  udp_datagram.msg[offset++] = context->rntiType;
 
   /* RNTI */
-  buffer[offset++] = MAC_LTE_RNTI_TAG;
-  tmp16 = htons(rnti);
-  memcpy(buffer + offset, &tmp16, 2);
+  udp_datagram.msg[offset++] = MAC_LTE_RNTI_TAG;
+  tmp16 = htons(context->rnti);
+  memcpy(udp_datagram.msg + offset, &tmp16, 2);
   offset += 2;
 
   /* UEId */
-  buffer[offset++] = MAC_LTE_UEID_TAG;
-  tmp16 = htons(ueid);
-  memcpy(buffer + offset, &tmp16, 2);
+  udp_datagram.msg[offset++] = MAC_LTE_UEID_TAG;
+  tmp16 = htons(context->ueid);
+  memcpy(udp_datagram.msg + offset, &tmp16, 2);
   offset += 2;
 
   /* Subframe Number and System Frame Number */
   /* SFN is stored in 12 MSB and SF in 4 LSB */
-  buffer[offset++] = MAC_LTE_FRAME_SUBFRAME_TAG;
-  tmp16 = (((uint16_t)(tti/10)) << 4) | (uint16_t)(tti%10);
+
+  udp_datagram.msg[offset++] = MAC_LTE_FRAME_SUBFRAME_TAG;
+  tmp16 = (context->sysFrameNumber << 4) | context->subFrameNumber;
   tmp16 = htons(tmp16);
-  memcpy(buffer + offset, &tmp16, 2);
+  memcpy(udp_datagram.msg + offset, &tmp16, 2);
   offset += 2;
 
   /* CRC Status */
-  buffer[offset++] = MAC_LTE_CRC_STATUS_TAG;
-  buffer[offset++] = crc_ok;
+  udp_datagram.msg[offset++] = MAC_LTE_CRC_STATUS_TAG;
+  udp_datagram.msg[offset++] = context->crcStatusOK;
 
   /* Data tag immediately preceding PDU */
-  buffer[offset++] = MAC_LTE_PAYLOAD_TAG;
+  udp_datagram.msg[offset++] = MAC_LTE_PAYLOAD_TAG;
 
   /* Write PDU data into buffer */
   if (pdu != NULL) {
-    memcpy(buffer + offset, (void*)pdu, pdu_len_bytes);
+    memcpy(udp_datagram.msg + offset, (void*)pdu, pdu_len_bytes);
     offset += pdu_len_bytes;
   }
   // Remote IP 
-  bytes_sent = sendto(socket_d, buffer, offset, 0, (const struct sockaddr *) &client_addr, sizeof(client_addr));
+  // TODO: sendto thread safe with mutex
+  bytes_sent = sendto(socket_d, udp_datagram.msg, offset, 0, (const struct sockaddr *) &client_addr, sizeof(client_addr));
 
   if (bytes_sent != offset) {
     printf("Failed to sent MAC UDP Frame (expected %d bytes, sent %d, (errno %d))\n", offset, bytes_sent, errno);
   }
-
+  bzero(udp_datagram.msg, offset);
+  udp_datagram.reset();
 }
 
-}
-
-
+} //namespace

--- a/lib/src/common/live_mac_trace.cc
+++ b/lib/src/common/live_mac_trace.cc
@@ -120,7 +120,10 @@ void live_mac_trace::pack_and_queue(uint8_t* pdu, uint32_t pdu_len_bytes, uint32
   
   udp_pdu = pool->allocate();
 
-  memcpy(udp_pdu->msg, pdu, pdu_len_bytes);
+  if(pdu != NULL){
+    memcpy(udp_pdu->msg, pdu, pdu_len_bytes);
+  }
+ 
   udp_pdu->N_bytes = pdu_len_bytes;
 
   mac_trace_pdu.pdu = udp_pdu;

--- a/lib/src/common/live_mac_trace.cc
+++ b/lib/src/common/live_mac_trace.cc
@@ -198,7 +198,7 @@ void live_mac_trace::send_mac_datagram(uint8_t* pdu, uint32_t pdu_len_bytes, MAC
   bytes_sent = sendto(socket_d, udp_datagram.msg, offset, 0, (const struct sockaddr *) &client_addr, sizeof(client_addr));
 
   if (bytes_sent != offset) {
-    printf("Failed to sent MAC UDP Frame (expected %d bytes, sent %d, (errno %d))\n", offset, bytes_sent, errno);
+    printf("Failed to sent MAC UDP Frame (expected %d bytes, sent %zu, (errno %d))\n", offset, bytes_sent, errno);
   }
   bzero(udp_datagram.msg, offset);
   udp_datagram.reset();

--- a/lib/test/common/CMakeLists.txt
+++ b/lib/test/common/CMakeLists.txt
@@ -47,4 +47,7 @@ target_link_libraries(log_filter_test srslte_phy srslte_common srslte_phy ${SEC_
 add_executable(timeout_test timeout_test.cc)
 target_link_libraries(timeout_test srslte_phy ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(live_mac_trace_test live_mac_trace_test.cc)
+target_link_libraries(live_mac_trace_test srslte_common ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(bcd_helpers_test bcd_helpers_test.cc)

--- a/lib/test/common/live_mac_trace_test.cc
+++ b/lib/test/common/live_mac_trace_test.cc
@@ -1,0 +1,111 @@
+/**
+ *
+ * \section COPYRIGHT
+ *
+ * Copyright 2013-2018 Software Radio Systems Limited
+ *
+ * \section LICENSE
+ *
+ * This file is part of the srsUE library.
+ *
+ * srsUE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsUE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#include <stdio.h>
+#include <assert.h>
+
+#include "srslte/common/live_mac_trace.h"
+#include "srslte/common/threads.h"
+
+
+using namespace srslte;
+
+
+uint8_t pdu[] = {0x23, 0x38, 0x1f, 0xa0, 0x45, 0x80, 0x74, 0x21, 0xb1, 0xc4, 0xd4, 0x1f, 0x25, 0x02, 0xd8, 0x6a,
+0xfe, 0xfc, 0x1b, 0x4f, 0x01, 0xfc, 0x24, 0xb7, 0xce, 0x59, 0xc4, 0xde, 0xa7, 0x52, 0x07, 0x00,
+0x41, 0x75, 0x29, 0xc0, 0x73, 0x0c, 0x57, 0x9f, 0x44, 0x1d, 0x27, 0xcb, 0xb3, 0xd1, 0xf6, 0xb7,
+0x7e, 0x4f, 0x11, 0xfa, 0x53, 0x9c, 0xeb, 0xec, 0x1e, 0x9a, 0x2b, 0x4a, 0x87, 0xeb, 0x7b, 0x07,
+0x46, 0x1e, 0x21};
+
+#define EXPECTED_UDP_SIZE 89
+
+class test_thread : public thread
+{
+public:
+  void init(char * client_ip_addr_, uint16_t client_udp_port_){
+    // Creating socket file descriptor 
+    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) { 
+      perror("socket creation failed"); 
+      return;
+    } 
+
+    client_addr.sin_family = AF_INET;
+    client_addr.sin_addr.s_addr = inet_addr(client_ip_addr_);
+    client_addr.sin_port = htons(client_udp_port_);
+
+    int ret = bind(sockfd, (struct sockaddr*) &client_addr, sizeof(client_addr));
+
+    if (ret != 0) {
+      printf("Failed to bind socket to (%s:%u)\n",
+            inet_ntoa(client_addr.sin_addr),
+            ntohs(client_addr.sin_port));
+      close(sockfd);
+      return;
+    }
+   
+    running = true;
+    start();
+  }
+
+  void run_thread(){;
+    int n, len; 
+    socklen_t socklen = sizeof(client_addr);
+    while(running){
+      n = recvfrom(sockfd, (char *)buffer, 1024,  
+                  0, (struct sockaddr *) &client_addr, 
+                  &socklen);
+      assert(EXPECTED_UDP_SIZE == n);
+      // TODO: Check buffer...
+    }
+    return; 
+  }
+
+  void stop(){
+    running = false;
+    close(sockfd); 
+  }
+
+private:
+    int sockfd; 
+    char buffer[1024]; 
+    struct sockaddr_in     client_addr; 
+    bool running;
+};
+
+
+int main(int argc, char **argv) {
+  char server_ip_addr[] = "127.0.0.1";
+  uint16_t server_udp_port = 5687;
+  char client_ip_addr[] = "127.0.0.1";
+  uint16_t client_udp_port = 5847;
+  live_mac_trace mac_trace;
+  mac_trace.init(server_ip_addr, server_udp_port, client_ip_addr, client_udp_port);
+
+  test_thread test_threat_a;
+  test_threat_a.init(client_ip_addr, client_udp_port);
+  mac_trace.write_dl_crnti(pdu, sizeof(pdu), 60128, true, 2133);
+  test_threat_a.stop();
+}

--- a/lib/test/common/live_mac_trace_test.cc
+++ b/lib/test/common/live_mac_trace_test.cc
@@ -105,7 +105,11 @@ int main(int argc, char **argv) {
   mac_trace.init(server_ip_addr, server_udp_port, client_ip_addr, client_udp_port);
   test_thread test_threat_a;
   test_threat_a.init(client_ip_addr, client_udp_port);
-  mac_trace.write_dl_crnti(pdu, sizeof(pdu), 60128, true, 2133);
+  int i = 0;
+  for (i = 0; i < 100; i++){
+    mac_trace.write_dl_crnti(pdu, sizeof(pdu), 60128, true, 2133);
+    sleep(0.001);
+  }
   sleep(0.05);
   test_threat_a.stop();
   mac_trace.stop();

--- a/lib/test/common/live_mac_trace_test.cc
+++ b/lib/test/common/live_mac_trace_test.cc
@@ -103,9 +103,10 @@ int main(int argc, char **argv) {
   uint16_t client_udp_port = 5847;
   live_mac_trace mac_trace;
   mac_trace.init(server_ip_addr, server_udp_port, client_ip_addr, client_udp_port);
-
   test_thread test_threat_a;
   test_threat_a.init(client_ip_addr, client_udp_port);
   mac_trace.write_dl_crnti(pdu, sizeof(pdu), 60128, true, 2133);
+  sleep(0.05);
   test_threat_a.stop();
+  mac_trace.stop();
 }

--- a/srsenb/enb.conf.example
+++ b/srsenb/enb.conf.example
@@ -92,6 +92,34 @@ rx_gain = 40
 enable = false
 filename = /tmp/enb.pcap
 
+
+#####################################################################
+# MAC-layer live capture configuration
+#
+# Packets are sent live over UDP to a destination host and 
+# traces can be anaylized just in time by Wireshark. To use the 
+# dissector, activate 'Try heuristic sub-dissectors first' 
+# under UDP protocol preferences. Depending of version of Wireshark 
+# version, you need activate 'Try Heuristic LTE-MAC over UDP framing'
+# under the MAC-LTE protocol preferences. For Wireshark > 2.0 you 
+# find the heuristic activation in the 'Enabled Protocols' window
+# in the analyze menu (mac_lte_udp). 
+# For more information see: https://wiki.wireshark.org/MAC-LTE
+#
+# enable:   Enable MAC layer packet captures (true/false)
+# src_ip: File path to use for packet captures
+# src_port: File path to use for packet captures
+# dst_ip: File path to use for packet captures
+# dst_port: File path to use for packet captures
+#####################################################################
+
+[live_trace]
+enable = false
+src_ip = 127.0.0.1
+src_port = 5687
+dst_ip = 127.0.0.1
+dst_port = 5647
+
 #####################################################################
 # Log configuration
 #

--- a/srsenb/hdr/enb.h
+++ b/srsenb/hdr/enb.h
@@ -53,6 +53,7 @@
 #include "srslte/common/logger_file.h"
 #include "srslte/common/log_filter.h"
 #include "srslte/common/mac_pcap.h"
+#include "srslte/common/live_mac_trace.h"
 #include "srslte/interfaces/sched_interface.h"
 #include "srslte/interfaces/enb_metrics_interface.h"
 
@@ -96,6 +97,14 @@ typedef struct {
 }pcap_args_t;
 
 typedef struct {
+  bool enable;
+  std::string src_ip;
+  uint16_t src_port;
+  std::string dst_ip;
+  uint16_t dst_port;
+}live_trace_args_t;
+
+typedef struct {
   std::string   phy_level;
   std::string   phy_lib_level;
   std::string   mac_level;
@@ -136,6 +145,7 @@ typedef struct {
   rf_args_t     rf;
   rf_cal_t      rf_cal; 
   pcap_args_t   pcap;
+  live_trace_args_t trace;
   log_args_t    log;
   gui_args_t    gui;
   expert_args_t expert;
@@ -183,6 +193,7 @@ private:
   srsenb::phy phy;
   srsenb::mac mac;
   srslte::mac_pcap mac_pcap;
+  srslte::live_mac_trace mac_trace;
   srsenb::rlc rlc;
   srsenb::pdcp pdcp;
   srsenb::rrc rrc;

--- a/srsenb/hdr/mac/mac.h
+++ b/srsenb/hdr/mac/mac.h
@@ -36,6 +36,7 @@
 #include "srslte/common/threads.h"
 #include "srslte/common/tti_sync_cv.h"
 #include "srslte/common/mac_pcap.h"
+#include "srslte/common/live_mac_trace.h"
 #include "scheduler.h"
 #include "scheduler_metric.h"
 #include "srslte/interfaces/enb_metrics_interface.h"
@@ -67,6 +68,7 @@ public:
   void stop();
   
   void start_pcap(srslte::mac_pcap* pcap_);
+  void start_trace(srslte::live_mac_trace * mac_trace_);
   
   /******** Interface from PHY (PHY -> MAC) ****************/ 
   int sr_detected(uint32_t tti, uint16_t rnti); 
@@ -194,6 +196,9 @@ private:
   
   // pointer to MAC PCAP object
   srslte::mac_pcap* pcap;
+
+  // pointer to MAC over UDP object
+  srslte::live_mac_trace* mac_trace;
   
 
   /* Class to run upper-layer timers with normal priority */

--- a/srsenb/hdr/mac/ue.h
+++ b/srsenb/hdr/mac/ue.h
@@ -30,6 +30,7 @@
 #include "srslte/common/log.h"
 #include "srslte/common/pdu.h"
 #include "srslte/common/mac_pcap.h"
+#include "srslte/common/live_mac_trace.h"
 #include "srslte/common/pdu_queue.h"
 #include "srslte/interfaces/enb_interfaces.h"
 #include "srslte/interfaces/sched_interface.h"
@@ -55,6 +56,7 @@ public:
     log_h = NULL; 
     rnti  = 0; 
     pcap  = NULL;
+    mac_trace = NULL;
     nof_failures   = 0;
     phr_counter    = 0;
     dl_cqi_counter = 0;
@@ -84,6 +86,7 @@ public:
   void     reset();
   
   void     start_pcap(srslte::mac_pcap* pcap_);
+  void     start_trace(srslte::live_mac_trace * mac_trace_);
   void     set_tti(uint32_t tti); 
   
   void     config(uint16_t rnti, uint32_t nof_prb, sched_interface *sched, rrc_interface_mac *rrc_, rlc_interface_mac *rlc, srslte::log *log_h);
@@ -131,6 +134,7 @@ private:
   mac_metrics_t metrics;
   
   srslte::mac_pcap* pcap;
+  srslte::live_mac_trace* mac_trace;
   
   uint64_t conres_id;
   

--- a/srsenb/src/enb.cc
+++ b/srsenb/src/enb.cc
@@ -131,6 +131,12 @@ bool enb::init(all_args_t *args_)
     mac_pcap.open(args->pcap.filename.c_str());
     mac.start_pcap(&mac_pcap);
   }
+
+  if(args->trace.enable)
+  {
+    mac_trace.init(args->trace.src_ip.c_str(), args->trace.src_port, args->trace.dst_ip.c_str(), args->trace.dst_port);
+    mac.start_trace(&mac_trace);
+  }
   
   // Init layers
   
@@ -266,6 +272,10 @@ void enb::stop()
     if(args->pcap.enable)
     {
        mac_pcap.close();
+    }
+    if(args->trace.enable)
+    {
+      mac_trace.stop();
     }
     radio.stop();
     started = false;

--- a/srsenb/src/mac/ue.cc
+++ b/srsenb/src/mac/ue.cc
@@ -82,6 +82,11 @@ void ue::start_pcap(srslte::mac_pcap* pcap_)
   pcap = pcap_; 
 }
 
+void ue::start_trace(srslte::live_mac_trace* mac_trace_)
+{
+  mac_trace = mac_trace_;
+}
+
 uint32_t ue::rl_failure()
 {
   nof_failures++;
@@ -148,6 +153,10 @@ void ue::process_pdu(uint8_t* pdu, uint32_t nof_bytes, srslte::pdu_queue::channe
 
   if (pcap) {
     pcap->write_ul_crnti(pdu, nof_bytes, rnti, true, last_tti);
+  }
+
+  if (mac_trace) {
+    mac_trace->write_ul_crnti(pdu, nof_bytes, rnti, true, last_tti);
   }
 
   pdus.deallocate(pdu);

--- a/srsenb/src/main.cc
+++ b/srsenb/src/main.cc
@@ -103,6 +103,12 @@ void parse_args(all_args_t *args, int argc, char* argv[]) {
     ("pcap.enable",       bpo::value<bool>(&args->pcap.enable)->default_value(false),           "Enable MAC packet captures for wireshark")
     ("pcap.filename",     bpo::value<string>(&args->pcap.filename)->default_value("ue.pcap"),   "MAC layer capture filename")
 
+    ("live_trace.enable",   bpo::value<bool>(&args->trace.enable)->default_value(false),          "Enable MAC packet live over UDP for wireshark")
+    ("live_trace.src_ip",   bpo::value<string>(&args->trace.src_ip)->default_value("127.0.0.1"),  "Source IP for UDP packets")
+    ("live_trace.src_port", bpo::value<uint16_t>(&args->trace.src_port)->default_value(5687),     "Source Port for UDP packets")
+    ("live_trace.dst_ip",   bpo::value<string>(&args->trace.dst_ip)->default_value("127.0.0.1"),  "Destination IP for UDP packets")
+    ("live_trace.dst_port", bpo::value<uint16_t>(&args->trace.dst_port)->default_value(5647),     "Destination Port for UDP packets")
+    
     ("gui.enable",        bpo::value<bool>(&args->gui.enable)->default_value(false),            "Enable GUI plots")
 
     ("log.phy_level",     bpo::value<string>(&args->log.phy_level),   "PHY log level")


### PR DESCRIPTION
Hi,

I have added a live MAC layer trace functionality, that allows to retrieve a live trace on the mac layer. The mac frame is encapsulated into a UDP datagram and can be decoded with wireshark and the heuristic decoder. 

Best regards,
David