### PR TITLE
eNB erab_info clobber and UE integrity check result in duplicate ip address (#215 rebased)

### DIFF
--- a/srsenb/hdr/upper/rrc.h
+++ b/srsenb/hdr/upper/rrc.h
@@ -296,6 +296,7 @@ public:
     int cqi_sched_sf_idx; 
     int cqi_sched_prb_idx;
     int get_drbid_config(LIBLTE_RRC_DRB_TO_ADD_MOD_STRUCT *drb, int drbid);
+    srslte::byte_buffer_t erab_info;
   }; 
   
   
@@ -333,8 +334,7 @@ private:
   srslte::byte_buffer_pool  *pool;
   srslte::bit_buffer_t  bit_buf;
   srslte::bit_buffer_t  bit_buf_paging;
-  srslte::byte_buffer_t erab_info;
-    
+
   phy_interface_rrc    *phy;
   mac_interface_rrc    *mac;
   rlc_interface_rrc    *rlc;

--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -1225,8 +1225,9 @@ void rrc::ue::setup_erab(uint8_t id, LIBLTE_S1AP_E_RABLEVELQOSPARAMETERS_STRUCT 
   parent->gtpu->add_bearer(rnti, lcid, addr_, erabs[id].teid_out, &(erabs[id].teid_in));
 
   if(nas_pdu) {
-    memcpy(parent->erab_info.msg, nas_pdu->buffer, nas_pdu->n_octets);
-    parent->erab_info.N_bytes = nas_pdu->n_octets;
+    memcpy(erab_info.buffer, nas_pdu->buffer, nas_pdu->n_octets);
+    erab_info.N_bytes = nas_pdu->n_octets;
+    parent->rrc_log->info_hex(erab_info.buffer, erab_info.N_bytes, "setup_erab nas_pdu -> erab_info rnti 0x%x", rnti);
   }
 }
 
@@ -1665,9 +1666,11 @@ void rrc::ue::send_connection_reconf(srslte::byte_buffer_t *pdu)
 
   // Add NAS Attach accept 
   conn_reconf->N_ded_info_nas = 1; 
-  conn_reconf->ded_info_nas_list[0].N_bytes = parent->erab_info.N_bytes;
-  memcpy(conn_reconf->ded_info_nas_list[0].msg, parent->erab_info.msg, parent->erab_info.N_bytes);
-  
+
+  parent->rrc_log->info_hex(erab_info.buffer, erab_info.N_bytes, "connection_reconf erab_info -> nas_info rnti 0x%x\n", rnti);
+  conn_reconf->ded_info_nas_list[0].N_bytes = erab_info.N_bytes;
+  memcpy(conn_reconf->ded_info_nas_list[0].msg, erab_info.buffer, erab_info.N_bytes);
+ 
   // Reuse same PDU
   pdu->reset();
   
@@ -1723,8 +1726,9 @@ void rrc::ue::send_connection_reconf_new_bearer(LIBLTE_S1AP_E_RABTOBESETUPLISTBE
     // DRB has already been configured in GTPU through bearer setup
 
     // Add NAS message
-    conn_reconf->ded_info_nas_list[conn_reconf->N_ded_info_nas].N_bytes = parent->erab_info.N_bytes;
-    memcpy(conn_reconf->ded_info_nas_list[conn_reconf->N_ded_info_nas].msg, parent->erab_info.msg, parent->erab_info.N_bytes);
+    parent->rrc_log->info_hex(erab_info.buffer, erab_info.N_bytes, "reconf_new_bearer erab_info -> nas_info rnti 0x%x\n", rnti);
+    conn_reconf->ded_info_nas_list[conn_reconf->N_ded_info_nas].N_bytes = erab_info.N_bytes;
+    memcpy(conn_reconf->ded_info_nas_list[conn_reconf->N_ded_info_nas].msg, erab_info.buffer, erab_info.N_bytes);
     conn_reconf->N_ded_info_nas++;
   }
 

--- a/srsue/src/upper/nas.cc
+++ b/srsue/src/upper/nas.cc
@@ -301,9 +301,14 @@ void nas::write_pdu(uint32_t lcid, byte_buffer_t *pdu) {
     case LIBLTE_MME_SECURITY_HDR_TYPE_INTEGRITY:
         break;
     case LIBLTE_MME_SECURITY_HDR_TYPE_INTEGRITY_AND_CIPHERED:
-        mac_valid = integrity_check(pdu);
-        cipher_decrypt(pdu);
-        break;
+        if((mac_valid = integrity_check(pdu))) {
+          cipher_decrypt(pdu);
+          break;
+        } else {
+          nas_log->error("Not handling NAS message with integrity check error\n");
+          pool->deallocate(pdu);
+          return;
+        }
     case LIBLTE_MME_SECURITY_HDR_TYPE_INTEGRITY_AND_CIPHERED_WITH_NEW_EPS_SECURITY_CONTEXT:
         break;
     default:


### PR DESCRIPTION
in rapid multiple ue attach condition enb to ue reconfig data could be clobbered before it is sent. Made temporary config storage unique per ue (rnti).
Above condition was causing an integrity check error at the receiver but was ignored resulting in multiple ue's with the same ip address.