### PR TITLE
added config option for tun dev names and M1 interface rebase(#222 and #207)

### DIFF
--- a/srsenb/hdr/enb.h
+++ b/srsenb/hdr/enb.h
@@ -69,6 +69,8 @@ typedef struct {
   uint32_t    nof_ports;
   uint32_t    transmission_mode;
   float       p_a;
+  std::string m1u_bind_addr;
+  std::string m1u_multi_addr;
 }enb_args_t;
 
 typedef struct {

--- a/srsenb/hdr/upper/gtpu.h
+++ b/srsenb/hdr/upper/gtpu.h
@@ -58,6 +58,24 @@ namespace srsenb {
 
 #define GTPU_HEADER_LEN 8
 
+// local gtp, mme and m1-u config passed via enb args
+struct gtpu_config_t{
+ const std::string gtp_bind_addr;
+ const std::string mme_addr;
+ const std::string m1u_bind_addr;
+ const std::string m1u_multi_addr;
+
+ gtpu_config_t(const std::string & gtp_bind_addr_,
+               const std::string & mme_addr_,
+               const std::string & m1u_bind_addr_,
+               const std::string & m1u_multi_addr_) :
+  gtp_bind_addr(gtp_bind_addr_),
+  mme_addr(mme_addr_),
+  m1u_bind_addr(m1u_bind_addr_),
+  m1u_multi_addr(m1u_multi_addr_)
+ { }
+};
+
 class gtpu
     :public gtpu_interface_rrc
     ,public gtpu_interface_pdcp
@@ -67,7 +85,7 @@ public:
 
   gtpu();
 
-  bool init(std::string gtp_bind_addr_, std::string mme_addr_, pdcp_interface_gtpu *pdcp_, srslte::log *gtpu_log_, bool enable_mbsfn = false);
+  bool init(const gtpu_config_t & config, pdcp_interface_gtpu *pdcp_, srslte::log *gtpu_log_, bool enable_mbsfn = false);
   void stop();
 
   // gtpu_interface_rrc
@@ -88,14 +106,28 @@ private:
   bool                         enable_mbsfn;
   std::string                  gtp_bind_addr;
   std::string                  mme_addr;
+  std::string                  m1u_bind_addr;
+  std::string                  m1u_multi_addr;
   srsenb::pdcp_interface_gtpu *pdcp;
   srslte::log                 *gtpu_log;
+
+  struct mch_config_t{
+    const std::string m1u_bind_addr;
+    const std::string m1u_multi_addr;
+
+    mch_config_t( const std::string & m1u_bind_addr_,
+                  const std::string & m1u_multi_addr_) :
+     m1u_bind_addr(m1u_bind_addr_),
+     m1u_multi_addr(m1u_multi_addr_)
+    { }
+};
+
 
   // Class to create
   class mch_thread : public thread {
   public:
     mch_thread() : initiated(false),running(false),run_enable(false),pool(NULL) {}
-    bool init(pdcp_interface_gtpu *pdcp_, srslte::log *gtpu_log_);
+    bool init(const mch_config_t & config, pdcp_interface_gtpu *pdcp_, srslte::log *gtpu_log_);
     void stop();
   private:
     void run_thread();
@@ -110,6 +142,8 @@ private:
     srslte::log         *gtpu_log;
     int m1u_sd;
     int lcid_counter;
+    std::string   m1u_bind_addr;
+    std::string   m1u_multi_addr;
 
     srslte::byte_buffer_pool *pool;
   };

--- a/srsenb/src/enb.cc
+++ b/srsenb/src/enb.cc
@@ -237,7 +237,11 @@ bool enb::init(all_args_t *args_)
   pdcp.init(&rlc, &rrc, &gtpu, &pdcp_log);
   rrc.init(&rrc_cfg, &phy, &mac, &rlc, &pdcp, &s1ap, &gtpu, &rrc_log);
   s1ap.init(args->enb.s1ap, &rrc, &s1ap_log);
-  gtpu.init(args->enb.s1ap.gtp_bind_addr, args->enb.s1ap.mme_addr, &pdcp, &gtpu_log, args->expert.enable_mbsfn);
+  gtpu.init(gtpu_config_t(args->enb.s1ap.gtp_bind_addr, 
+                          args->enb.s1ap.mme_addr,
+                          args->enb.m1u_multi_addr,
+                          args->enb.m1u_bind_addr),
+                          &pdcp, &gtpu_log, args->expert.enable_mbsfn);
   
   started = true;
   return true;

--- a/srsenb/src/main.cc
+++ b/srsenb/src/main.cc
@@ -83,6 +83,8 @@ void parse_args(all_args_t *args, int argc, char* argv[]) {
     ("enb.nof_ports",     bpo::value<uint32_t>(&args->enb.nof_ports)->default_value(1),            "Number of ports")
     ("enb.tm",            bpo::value<uint32_t>(&args->enb.transmission_mode)->default_value(1),    "Transmission mode (1-8)")
     ("enb.p_a",           bpo::value<float>(&args->enb.p_a)->default_value(0.0f),                  "Power allocation rho_a (-6, -4.77, -3, -1.77, 0, 1, 2, 3)")
+    ("enb.m1u_bind_addr", bpo::value<string>(&args->enb.m1u_bind_addr)->default_value("127.0.1.200"),  "Local IP address to bind for M1-U connection")
+    ("enb.m1u_multi_addr",bpo::value<string>(&args->enb.m1u_multi_addr)->default_value("239.255.0.1"), "Listen multicast group for M1-U connection")
 
     ("enb_files.sib_config", bpo::value<string>(&args->enb_files.sib_config)->default_value("sib.conf"),      "SIB configuration files")
     ("enb_files.rr_config",  bpo::value<string>(&args->enb_files.rr_config)->default_value("rr.conf"),      "RR configuration files")

--- a/srsepc/hdr/mbms-gw/mbms-gw.h
+++ b/srsepc/hdr/mbms-gw/mbms-gw.h
@@ -51,6 +51,7 @@ typedef struct {
   std::string sgi_mb_if_addr;
   std::string sgi_mb_if_mask;
   std::string m1u_multi_addr;
+  std::string m1u_bind_addr;
 } mbms_gw_args_t;
 
 struct pseudo_hdr

--- a/srsepc/hdr/spgw/spgw.h
+++ b/srsepc/hdr/spgw/spgw.h
@@ -50,6 +50,7 @@ const uint16_t GTPU_RX_PORT = 2152;
 typedef struct {
   std::string gtpu_bind_addr;
   std::string sgi_if_addr;
+  std::string sgi_if_name;
 } spgw_args_t;
 
 

--- a/srsepc/src/main.cc
+++ b/srsepc/src/main.cc
@@ -84,6 +84,7 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
   string mme_apn;
   string spgw_bind_addr;
   string sgi_if_addr;
+  string sgi_if_name;
   string dns_addr;
   string hss_db_file;
   string hss_auth_algo;
@@ -113,6 +114,7 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
     ("hss.auth_algo",       bpo::value<string>(&hss_auth_algo)->default_value("milenage"),"HSS uthentication algorithm.")
     ("spgw.gtpu_bind_addr", bpo::value<string>(&spgw_bind_addr)->default_value("127.0.0.1"),"IP address of SP-GW for the S1-U connection")
     ("spgw.sgi_if_addr",    bpo::value<string>(&sgi_if_addr)->default_value("176.16.0.1"),"IP address of TUN interface for the SGi connection")
+    ("spgw.sgi_if_name",    bpo::value<string>(&sgi_if_name)->default_value("srs_spgw_sgi"),"Name of TUN interface for the SGi connection")
 
     ("log.s1ap_level",     bpo::value<string>(&args->log_args.s1ap_level),   "MME S1AP log level")
     ("log.s1ap_hex_limit", bpo::value<int>(&args->log_args.s1ap_hex_limit),  "MME S1AP log hex dump limit")
@@ -213,6 +215,7 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
   args->mme_args.s1ap_args.mme_apn = mme_apn;
   args->spgw_args.gtpu_bind_addr = spgw_bind_addr;
   args->spgw_args.sgi_if_addr = sgi_if_addr;
+  args->spgw_args.sgi_if_name = sgi_if_name;
   args->hss_args.db_file = hss_db_file;
   args->hss_args.auth_algo = hss_auth_algo;
 

--- a/srsepc/src/mbms-gw/main.cc
+++ b/srsepc/src/mbms-gw/main.cc
@@ -85,6 +85,7 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
   string mbms_gw_sgi_mb_if_addr;
   string mbms_gw_sgi_mb_if_mask;
   string mbms_gw_m1u_multi_addr;
+  string mbms_gw_m1u_bind_addr;
 
   string log_filename;
 
@@ -103,6 +104,7 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
     ("mbms_gw.sgi_mb_if_addr",      bpo::value<string>(&mbms_gw_sgi_mb_if_addr)->default_value("172.16.1.1"), "SGi-mb TUN interface Address.")
     ("mbms_gw.sgi_mb_if_mask",      bpo::value<string>(&mbms_gw_sgi_mb_if_mask)->default_value("255.255.255.255"), "SGi-mb TUN interface mask.")
     ("mbms_gw.m1u_multi_addr",      bpo::value<string>(&mbms_gw_m1u_multi_addr)->default_value("239.255.0.1"), "M1-u GTPu destination multicast address.")
+    ("mbms_gw.m1u_bind_addr",       bpo::value<string>(&mbms_gw_m1u_bind_addr)->default_value("127.0.1.200"), "M1-u GTPu egress interface address.")
 
     ("log.all_level",     bpo::value<string>(&args->log_args.all_level)->default_value("info"),   "ALL log level")
     ("log.all_hex_limit", bpo::value<int>(&args->log_args.all_hex_limit)->default_value(32),  "ALL log hex dump limit")
@@ -156,6 +158,7 @@ parse_args(all_args_t *args, int argc, char* argv[]) {
   args->mbms_gw_args.sgi_mb_if_addr = mbms_gw_sgi_mb_if_addr;
   args->mbms_gw_args.sgi_mb_if_mask = mbms_gw_sgi_mb_if_mask;
   args->mbms_gw_args.m1u_multi_addr = mbms_gw_m1u_multi_addr;
+  args->mbms_gw_args.m1u_bind_addr  = mbms_gw_m1u_bind_addr;
 
   // Apply all_level to any unset layers
   if (vm.count("log.all_level")) {

--- a/srsepc/src/spgw/spgw.cc
+++ b/srsepc/src/spgw/spgw.cc
@@ -157,7 +157,6 @@ spgw::stop()
 srslte::error_t
 spgw::init_sgi_if(spgw_args_t *args)
 {
-  char dev[IFNAMSIZ] = "srs_spgw_sgi";
   struct ifreq ifr;
 
   if(m_sgi_up)
@@ -177,7 +176,7 @@ spgw::init_sgi_if(spgw_args_t *args)
 
   memset(&ifr, 0, sizeof(ifr));
   ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
-  strncpy(ifr.ifr_ifrn.ifrn_name, dev, IFNAMSIZ-1);
+  strncpy(ifr.ifr_ifrn.ifrn_name, args->sgi_if_name.c_str(), std::min(args->sgi_if_name.length(), (size_t)(IFNAMSIZ-1)));
   ifr.ifr_ifrn.ifrn_name[IFNAMSIZ-1]='\0';
 
   if(ioctl(m_sgi_if, TUNSETIFF, &ifr) < 0)

--- a/srsue/hdr/ue_base.h
+++ b/srsue/hdr/ue_base.h
@@ -111,6 +111,7 @@ typedef struct {
 
 typedef struct {
   std::string   ip_netmask;
+  std::string   ip_devname;
   phy_args_t    phy;
   float         metrics_period_secs;
   bool          pregenerate_signals;

--- a/srsue/hdr/upper/gw.h
+++ b/srsue/hdr/upper/gw.h
@@ -52,6 +52,7 @@ public:
 
   void get_metrics(gw_metrics_t &m);
   void set_netmask(std::string netmask);
+  void set_tundevname(const std::string & devname);
 
   // PDCP interface
   void write_pdu(uint32_t lcid, srslte::byte_buffer_t *pdu);
@@ -67,6 +68,7 @@ private:
 
   bool default_netmask;
   std::string netmask;
+  std::string tundevname;
 
   static const int GW_THREAD_PRIO = 7;
 

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -144,6 +144,10 @@ void parse_args(all_args_t *args, int argc, char *argv[]) {
      bpo::value<string>(&args->expert.ip_netmask)->default_value("255.255.255.0"),
      "Netmask of the tun_srsue device")
 
+    ("expert.ip_devname",
+     bpo::value<string>(&args->expert.ip_devname)->default_value("tun_srsue"),
+     "Name of the tun_srsue device")
+
      ("expert.mbms_service",
      bpo::value<int>(&args->expert.mbms_service)->default_value(-1),
      "automatically starts an mbms service of the number given")

--- a/srsue/src/ue.cc
+++ b/srsue/src/ue.cc
@@ -226,6 +226,7 @@ bool ue::init(all_args_t *args_) {
   nas.init(usim, &rrc, &gw, &nas_log, nas_cfg);
   gw.init(&pdcp, &nas, &gw_log, 3 /* RB_ID_DRB1 */);
   gw.set_netmask(args->expert.ip_netmask);
+  gw.set_tundevname(args->expert.ip_devname);
   rrc.init(&phy, &mac, &rlc, &pdcp, &nas, usim, &gw, &mac, &rrc_log);
   
   // Get current band from provided EARFCN

--- a/srsue/src/upper/gw.cc
+++ b/srsue/src/upper/gw.cc
@@ -45,6 +45,7 @@ gw::gw()
 {
   current_ip_addr = 0;
   default_netmask = true;
+  tundevname = "";
 }
 
 void gw::init(pdcp_interface_gw *pdcp_, nas_interface_gw *nas_, srslte::log *gw_log_, srslte::srslte_gw_config_t cfg_)
@@ -123,6 +124,11 @@ void gw::set_netmask(std::string netmask)
 {
   default_netmask = false;
   this->netmask = netmask;
+}
+
+void gw::set_tundevname(const std::string & devname)
+{
+  tundevname = devname;
 }
 
 
@@ -242,8 +248,6 @@ srslte::error_t gw::init_if(char *err_str)
     return(srslte::ERROR_ALREADY_STARTED);
   }
 
-  char dev[IFNAMSIZ] = "tun_srsue";
-
   // Construct the TUN device
   tun_fd = open("/dev/net/tun", O_RDWR);
   gw_log->info("TUN file descriptor = %d\n", tun_fd);
@@ -255,7 +259,7 @@ srslte::error_t gw::init_if(char *err_str)
   }
   memset(&ifr, 0, sizeof(ifr));
   ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
-  strncpy(ifr.ifr_ifrn.ifrn_name, dev, IFNAMSIZ-1);
+  strncpy(ifr.ifr_ifrn.ifrn_name, tundevname.c_str(), std::min(tundevname.length(), (size_t)(IFNAMSIZ-1)));
   ifr.ifr_ifrn.ifrn_name[IFNAMSIZ-1] = 0;
   if(0 > ioctl(tun_fd, TUNSETIFF, &ifr))
   {


### PR DESCRIPTION
r#222 added enb.m1u_bind_addr, enb.m1u_multi_addr and mbms_gw.m1u_bind_addr to allow M1-u over external interface. Best effort approach on allocating new config items to the correct arg_t's and passing config via init api.
#207 mbms device name was hard coded ignoring the optional configuration param mbms_gw.name
this patch removes the hardcoded value "sgi_mb" and applies the configuration value.