### PR TITLE
added support for optional ue static ip address (rebase #225)

### DIFF
--- a/srsepc/hdr/hss/hss.h
+++ b/srsepc/hdr/hss/hss.h
@@ -67,6 +67,7 @@ typedef struct{
     uint8_t  sqn[6];
     uint16_t qci;
     uint8_t  last_rand[16];
+    std::string static_ip_addr;
 }hss_ue_ctx_t;
 
 enum hss_auth_algo {
@@ -86,6 +87,8 @@ public:
   bool gen_update_loc_answer(uint64_t imsi, uint8_t* qci);
 
   bool resync_sqn(uint64_t imsi, uint8_t *auts);
+
+  std::map<std::string, uint64_t> get_ip_to_imsi() const;
 
 private:
 
@@ -132,6 +135,8 @@ private:
   
   uint16_t mcc;
   uint16_t mnc;
+
+  std::map<std::string, uint64_t> m_ip_to_imsi;
 };
 
 } // namespace srsepc

--- a/srsepc/hdr/spgw/spgw.h
+++ b/srsepc/hdr/spgw/spgw.h
@@ -40,6 +40,8 @@
 #include "srslte/common/buffer_pool.h"
 #include "srslte/common/threads.h"
 #include "srslte/asn1/gtpc.h"
+#include <map>
+#include <set>
 
 namespace srsepc{
 
@@ -70,7 +72,7 @@ class spgw:
 public:
   static spgw* get_instance(void);
   static void cleanup(void);
-  int init(spgw_args_t* args, srslte::log_filter *spgw_log);
+  int init(spgw_args_t* args, srslte::log_filter *spgw_log, const std::map<std::string, uint64_t> & ip_to_imsi);
   void stop();
   void run_thread();
 
@@ -90,11 +92,11 @@ private:
 
   srslte::error_t init_sgi_if(spgw_args_t *args);
   srslte::error_t init_s1u(spgw_args_t *args);
-  srslte::error_t init_ue_ip(spgw_args_t *args);
+  srslte::error_t init_ue_ip(spgw_args_t *args, const std::map<std::string, uint64_t> & ip_to_imsi);
 
   uint64_t get_new_ctrl_teid();
   uint64_t get_new_user_teid();
-  in_addr_t get_new_ue_ipv4();
+  in_addr_t get_new_ue_ipv4(uint64_t imsi);
 
   spgw_tunnel_ctx_t* create_gtp_ctx(struct srslte::gtpc_create_session_request *cs_req);
   bool delete_gtp_ctx(uint32_t ctrl_teid);
@@ -123,7 +125,8 @@ private:
   std::map<uint32_t,spgw_tunnel_ctx*> m_teid_to_tunnel_ctx;         //Map control TEID to tunnel ctx. Usefull to get reply ctrl TEID, UE IP, etc.
   std::map<in_addr_t,srslte::gtpc_f_teid_ie> m_ip_to_teid;          //Map IP to User-plane TEID for downlink traffic
 
-  uint32_t m_h_next_ue_ip;
+  std::set<uint32_t> m_ue_ip_addr_pool;
+  std::map<uint64_t, struct in_addr> m_imsi_to_ip;
 
   /*Time*/
   struct timeval m_t_last_dl;

--- a/srsepc/src/hss/hss.cc
+++ b/srsepc/src/hss/hss.cc
@@ -198,8 +198,8 @@ hss::read_db_file(std::string db_filename)
 
       // optional imsi to ip
       if(split.size() == column_size_2) {
-         char buf[128];
-         if(inet_ntop(AF_INET, split[8].c_str(), buf, sizeof(buf))) {
+         char buf[128] = {0};
+         if(inet_pton(AF_INET, split[8].c_str(), buf)) {
            if(m_ip_to_imsi.insert(std::make_pair(split[8], ue_ctx->imsi)).second) {
              ue_ctx->static_ip_addr = split[8];
              m_hss_log->info("static ip addr %s\n", ue_ctx->static_ip_addr.c_str());

--- a/srsepc/src/hss/hss.cc
+++ b/srsepc/src/hss/hss.cc
@@ -153,9 +153,10 @@ hss::read_db_file(std::string db_filename)
   {
     if(line[0] != '#')
     {
-      uint column_size = 8;
+      const uint column_size = 8;
+      const uint column_size_2 = 9; // optional static ip_addr
       std::vector<std::string> split = split_string(line,',');
-      if(split.size() != column_size)
+      if(split.size() != column_size && split.size() != column_size_2)
       {
         m_hss_log->error("Error parsing UE database. Wrong number of columns in .csv\n");
         m_hss_log->error("Columns: %lu, Expected %d.\n",split.size(),column_size);
@@ -194,6 +195,26 @@ hss::read_db_file(std::string db_filename)
       m_hss_log->debug_hex(ue_ctx->sqn, 6, "SQN : ");
       ue_ctx->qci = atoi(split[7].c_str());
       m_hss_log->debug("Default Bearer QCI: %d\n",ue_ctx->qci);
+
+      // optional imsi to ip
+      if(split.size() == column_size_2) {
+         char buf[128];
+         if(inet_ntop(AF_INET, split[8].c_str(), buf, sizeof(buf))) {
+           if(m_ip_to_imsi.insert(std::make_pair(split[8], ue_ctx->imsi)).second) {
+             ue_ctx->static_ip_addr = split[8];
+             m_hss_log->info("static ip addr %s\n", ue_ctx->static_ip_addr.c_str());
+           } else {
+             m_hss_log->info("duplicate static ip addr %s\n", split[8].c_str());
+             return false;
+           } 
+         } else {
+           m_hss_log->info("invalid static ip addr %s, %s\n", split[8].c_str(), strerror(errno));
+           return false;
+         }
+       } else {
+       ue_ctx->static_ip_addr = "0.0.0.0";
+     }
+
       m_imsi_to_ue_ctx.insert(std::pair<uint64_t,hss_ue_ctx_t*>(ue_ctx->imsi,ue_ctx));
     }
   }
@@ -262,6 +283,12 @@ bool hss::write_db_file(std::string db_filename)
       m_db_file << hex_string(it->second->sqn, 6);
       m_db_file << ",";
       m_db_file << it->second->qci;
+
+      // optional imsi to ip
+      if(it->second->static_ip_addr != "0.0.0.0"){
+        m_db_file << ",";
+        m_db_file << it->second->static_ip_addr;
+      }
       m_db_file << std::endl;
       it++;
   }
@@ -804,5 +831,10 @@ hss::hex_string(uint8_t *hex, int size)
     ss << std::setw(2) << static_cast<unsigned>(hex[i]);
   }
   return ss.str();
+}
+
+std::map<std::string, uint64_t> hss::get_ip_to_imsi(void) const
+{
+  return m_ip_to_imsi;
 }
 } //namespace srsepc

--- a/srsepc/src/main.cc
+++ b/srsepc/src/main.cc
@@ -370,7 +370,7 @@ main (int argc,char * argv[] )
   }
 
   spgw *spgw = spgw::get_instance();
-  if (spgw->init(&args.spgw_args,&spgw_log)) {
+  if (spgw->init(&args.spgw_args,&spgw_log, hss->get_ip_to_imsi())) {
     cout << "Error initializing SP-GW" << endl;
     exit(1);
   }

--- a/srsepc/src/spgw/spgw.cc
+++ b/srsepc/src/spgw/spgw.cc
@@ -83,7 +83,7 @@ spgw::cleanup(void)
 }
 
 int
-spgw::init(spgw_args_t* args, srslte::log_filter *spgw_log)
+spgw::init(spgw_args_t* args, srslte::log_filter *spgw_log, const std::map<std::string, uint64_t> & ip_to_imsi)
 {
   srslte::error_t err;
   m_pool = srslte::byte_buffer_pool::get_instance();
@@ -108,7 +108,7 @@ spgw::init(spgw_args_t* args, srslte::log_filter *spgw_log)
     return -1;
   }
   //Initialize UE ip pool
-  err = init_ue_ip(args);
+  err = init_ue_ip(args, ip_to_imsi);
   if (err != srslte::ERROR_NONE)
   {
     m_spgw_log->console("Could not initialize the S1-U interface.\n");
@@ -260,9 +260,57 @@ spgw::init_s1u(spgw_args_t *args)
 }
 
 srslte::error_t
-spgw::init_ue_ip(spgw_args_t *args)
+spgw::init_ue_ip(spgw_args_t *args, const std::map<std::string, uint64_t> & ip_to_imsi)
 {
-  m_h_next_ue_ip = ntohl(inet_addr(args->sgi_if_addr.c_str()));
+  std::map<std::string, uint64_t>::const_iterator iter = ip_to_imsi.find(args->sgi_if_addr);
+
+  // check for collision w/our ip address
+  if(iter != ip_to_imsi.end())
+    {
+      m_spgw_log->error("SPGW: static ip addr %s for imsi %lu, is reserved for the epc tun interface\n", 
+                        iter->first.c_str(), iter->second);
+
+      return srslte::ERROR_OUT_OF_BOUNDS;
+    }
+
+  // load our imsi to ip lookup table
+  for(std::map<std::string, uint64_t>::const_iterator iter = ip_to_imsi.begin(); iter != ip_to_imsi.end(); ++iter)
+    {
+      struct in_addr in_addr;
+
+      in_addr.s_addr = inet_addr(iter->first.c_str());
+
+      if(! m_imsi_to_ip.insert(std::make_pair(iter->second, in_addr)).second)
+        {
+          m_spgw_log->error("SPGW: duplicate imsi %lu for static ip address %s.\n", iter->second, iter->first.c_str());
+
+          return srslte::ERROR_OUT_OF_BOUNDS;
+        }
+    }
+
+  // XXX TODO add an upper bound to ip addr range via config, use 254 for now
+  // first address is allocated to the epc tun interface, start w/next addr
+  for(uint32_t n = 1; n < 254; ++n)
+   {
+     struct in_addr ue_addr;
+
+     ue_addr.s_addr = inet_addr(args->sgi_if_addr.c_str()) + htonl(n);
+
+     std::map<std::string, uint64_t>::const_iterator iter = ip_to_imsi.find(inet_ntoa(ue_addr));
+
+     if(iter != ip_to_imsi.end())
+      {
+        m_spgw_log->debug("SPGW: init_ue_ip ue ip addr %s is reserved for imsi %lu, not adding to pool\n", 
+                          iter->first.c_str(), iter->second);
+      }
+     else
+      {
+        m_ue_ip_addr_pool.insert(ue_addr.s_addr);
+
+        m_spgw_log->debug("SPGW: init_ue_ip ue ip addr %s is added to pool\n", inet_ntoa(ue_addr));
+      }
+   }
+
   return srslte::ERROR_NONE;
 }
 
@@ -420,10 +468,39 @@ spgw::get_new_user_teid()
 }
 
 in_addr_t
-spgw::get_new_ue_ipv4()
+spgw::get_new_ue_ipv4(uint64_t imsi)
 {
-  m_h_next_ue_ip++;
-  return ntohl(m_h_next_ue_ip);//FIXME Tmp hack
+   struct in_addr ue_addr;
+
+   std::map<uint64_t, struct in_addr>::const_iterator iter = m_imsi_to_ip.find(imsi);
+
+   // check imsi to ip mapping
+   if(iter != m_imsi_to_ip.end())
+     {
+       ue_addr = iter->second;
+
+       m_spgw_log->info("SPGW: get_new_ue_ipv4 static ip addr %s\n", inet_ntoa(ue_addr));
+     }
+   else
+     {
+       if(m_ue_ip_addr_pool.empty())
+        {
+          m_spgw_log->error("SPGW: ue address pool is empty\n");
+
+          ue_addr.s_addr = 0;
+        }
+     else
+       {
+         ue_addr.s_addr = *m_ue_ip_addr_pool.begin();
+
+         // now remove from pool 
+         m_ue_ip_addr_pool.erase(ue_addr.s_addr);
+
+         m_spgw_log->info("SPGW: get_new_ue_ipv4 pool ip addr %s\n", inet_ntoa(ue_addr));
+       }
+   }
+
+  return ue_addr.s_addr;
 }
 
 spgw_tunnel_ctx_t*
@@ -433,9 +510,8 @@ spgw::create_gtp_ctx(struct srslte::gtpc_create_session_request *cs_req)
   uint64_t spgw_uplink_ctrl_teid = get_new_ctrl_teid();
   //Setup uplink user TEID
   uint64_t spgw_uplink_user_teid = get_new_user_teid();
-  //Allocate UE IP
-  in_addr_t ue_ip = get_new_ue_ipv4();
-  //in_addr_t ue_ip = inet_addr("172.16.0.2");
+  //Allocate UE IP XXX TODO check for valid non-zero address and return error code
+  in_addr_t ue_ip = get_new_ue_ipv4(cs_req->imsi);
   uint8_t default_bearer_id = 5;
 
   m_spgw_log->console("SPGW: Allocated Ctrl TEID %" PRIu64 "\n", spgw_uplink_ctrl_teid);


### PR DESCRIPTION
Added support for optional parameter in user_db.csv to assign an ip address per ue entry.
ue2,001010123456780,00112233445566778899aabbccddeeff,opc,63bfa50ee6523365ff14c1f45f88737d,8000,000000001234,7,172.16.0.3
ue1,001010123456789,00112233445566778899aabbccddeeff,opc,63bfa50ee6523365ff14c1f45f88737d,9001,000000001272,9

09:53:23.622181 [SPGW] [I] TUN file descriptor = 5
09:53:23.625752 [SPGW] [I] S1-U socket = 7
09:53:23.625782 [SPGW] [I] S1-U IP = 127.0.1.100, Port = 2152
09:53:23.625795 [SPGW] [D] SPGW: init_ue_ip ue ip addr 172.16.0.2 is added to pool
09:53:23.625801 [SPGW] [D] SPGW: init_ue_ip ue ip addr 172.16.0.3 is reserved for imsi 1010123456780, not adding to pool
09:53:23.625806 [SPGW] [D] SPGW: init_ue_ip ue ip addr 172.16.0.4 is added to pool
09:53:23.625811 [SPGW] [D] SPGW: init_ue_ip ue ip addr 172.16.0.5 is added to pool
09:53:23.625816 [SPGW] [D] SPGW: init_ue_ip ue ip addr 172.16.0.6 is added to pool