### PR TITLE
added generaic queue metrics to rlc metrics

### DIFF
--- a/lib/include/srslte/common/block_queue.h
+++ b/lib/include/srslte/common/block_queue.h
@@ -45,6 +45,8 @@
 #include <unistd.h>
 #include <strings.h>
 
+#include "srslte/common/queue_metrics.h"
+
 namespace srslte {
 
 template<typename myobj>
@@ -67,6 +69,7 @@ public:
     mutexed_callback = NULL;
     enable = true;
     num_threads = 0;
+    qmetrics.capacity = capacity;
   }
   ~block_queue() {
     // Unlock threads waiting at push or pop
@@ -92,7 +95,10 @@ public:
     mutexed_callback = itf;
   }
   void resize(int new_capacity) {
+    pthread_mutex_lock(&mutex);
     capacity = new_capacity;
+    qmetrics.capacity = capacity;
+    pthread_mutex_unlock(&mutex);
   }
 
   void push(const myobj& value) {
@@ -122,7 +128,9 @@ public:
 
   void clear() { // remove all items
     myobj *item = NULL;
-    while (try_pop(item));
+    while (try_pop(item)) {
+      ++qmetrics.num_cleared;
+    }
   }
 
   myobj front() {
@@ -130,31 +138,51 @@ public:
   }
 
   size_t size() {
-    return q.size();
+    pthread_mutex_lock(&mutex);
+    size_t result = q.size();
+    pthread_mutex_unlock(&mutex);
+    return result;
   }
 
+  queue_metrics_t get_qmetrics(bool bReset) {
+    pthread_mutex_lock(&mutex);
+    const queue_metrics_t result = qmetrics;
+    if(bReset) {
+      qmetrics.reset();
+    }
+    pthread_mutex_unlock(&mutex);
+    return result;
+  }
+   
 private:
 
   bool pop_(myobj *value, bool block) {
     if (!enable) {
+      ++qmetrics.num_pop_fail;
       return false;
     }
     pthread_mutex_lock(&mutex);
     num_threads++;
     bool ret = false;
     if (q.empty() && !block) {
+      ++qmetrics.num_pop_fail;
       goto exit;
     }
     while (q.empty() && enable) {
       pthread_cond_wait(&cv_empty, &mutex);
     }
     if (!enable) {
+      ++qmetrics.num_pop_fail;
       goto exit;
     }
     if (value) {
       *value = q.front();
     }
+
     q.pop();
+    ++qmetrics.num_pop;
+    qmetrics.currsize = q.size();
+
     ret = true;
     if (mutexed_callback) {
       mutexed_callback->popping(*value);
@@ -168,6 +196,7 @@ private:
 
   bool push_(const myobj& value, bool block) {
     if (!enable) {
+      ++qmetrics.num_push_fail;
       return false;
     }
     pthread_mutex_lock(&mutex);
@@ -179,13 +208,20 @@ private:
           pthread_cond_wait(&cv_full, &mutex);
         }
         if (!enable) {
+          ++qmetrics.num_push_fail;
           goto exit;
         }
       } else if (q.size() >= (uint32_t) capacity) {
+        ++qmetrics.num_push_fail;
         goto exit;
       }
     }
+
     q.push(value);
+    ++qmetrics.num_push;
+    qmetrics.currsize = q.size();
+    qmetrics.highwater = std::max(qmetrics.highwater, q.size());
+
     ret = true;
     if (mutexed_callback) {
       mutexed_callback->pushing(value);
@@ -205,6 +241,8 @@ private:
   int capacity;
   bool enable;
   uint32_t num_threads;
+
+  queue_metrics_t qmetrics;
 };
 
 }

--- a/lib/include/srslte/common/queue_metrics.h
+++ b/lib/include/srslte/common/queue_metrics.h
@@ -1,0 +1,94 @@
+/**
+ *
+ * \section COPYRIGHT
+ *
+ * Copyright 2018 Software Radio Systems Limited
+ *
+ * \section LICENSE
+ *
+ * This file is part of the srsUE library.
+ *
+ * srsUE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsUE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+
+/******************************************************************************
+ *  File:         qmetrics.h
+ *  Description:  Generic queue metrics
+ *               
+ *              
+ *****************************************************************************/
+
+
+#ifndef QUEUE_METRICS_H
+#define QUEUE_METRICS_H
+
+#include <sstream>
+
+namespace srslte {
+
+  struct queue_metrics_t {
+   int    capacity;
+   size_t currsize;
+   size_t highwater;
+   size_t num_cleared;
+   size_t num_push;
+   size_t num_push_fail;
+   size_t num_pop;
+   size_t num_pop_fail;
+
+   queue_metrics_t() { 
+     reset();
+   }
+
+   void reset() {
+    capacity = 0;
+    currsize = 0;
+    highwater = 0;
+    num_cleared = 0;
+    num_push = 0;
+    num_push_fail = 0;
+    num_pop = 0;
+    num_pop_fail = 0;
+   }
+
+   std::string toString() const
+    {
+      std::stringstream ss;
+
+      ss << "cs=" 
+         << currsize
+         << ", hw="
+         << highwater
+         << ", cap="
+         << capacity
+         << ", nc="
+         << num_cleared
+         << ", npu="
+         << num_push
+         << ", npuf="
+         << num_push_fail
+         << ", npo="
+         << num_pop
+         << ", npof="
+         << num_pop_fail;
+
+       return ss.str();
+    }
+ };
+}
+
+#endif // QUEUE_METRICS_H

--- a/lib/include/srslte/interfaces/enb_metrics_interface.h
+++ b/lib/include/srslte/interfaces/enb_metrics_interface.h
@@ -52,6 +52,7 @@ typedef struct {
   mac_metrics_t   mac[ENB_METRICS_MAX_USERS];
   rrc_metrics_t   rrc; 
   s1ap_metrics_t  s1ap;
+  srslte::rlc_metrics_t rlc;
   bool            running;
 }enb_metrics_t;
 

--- a/lib/include/srslte/upper/rlc_am.h
+++ b/lib/include/srslte/upper/rlc_am.h
@@ -98,6 +98,7 @@ public:
   uint32_t get_num_rx_bytes();
   void reset_metrics();
 
+  queue_metrics_t get_qmetrics(bool bReset);
 private:
 
   // Transmitter sub-class
@@ -128,6 +129,7 @@ private:
     // Interface for Rx subclass
     void handle_control_pdu(uint8_t *payload, uint32_t nof_bytes);
 
+    queue_metrics_t get_qmetrics(bool bReset);
   private:
 
     int  build_status_pdu(uint8_t *payload, uint32_t nof_bytes);

--- a/lib/include/srslte/upper/rlc_common.h
+++ b/lib/include/srslte/upper/rlc_common.h
@@ -28,7 +28,6 @@
 #define SRSLTE_RLC_COMMON_H
 
 #include "srslte/upper/rlc_interface.h"
-#include "srslte/common/block_queue.h"
 
 namespace srslte {
 

--- a/lib/include/srslte/upper/rlc_common.h
+++ b/lib/include/srslte/upper/rlc_common.h
@@ -28,6 +28,7 @@
 #define SRSLTE_RLC_COMMON_H
 
 #include "srslte/upper/rlc_interface.h"
+#include "srslte/common/block_queue.h"
 
 namespace srslte {
 
@@ -173,6 +174,8 @@ public:
   virtual uint32_t get_total_buffer_state() = 0;
   virtual int      read_pdu(uint8_t *payload, uint32_t nof_bytes) = 0;
   virtual void     write_pdu(uint8_t *payload, uint32_t nof_bytes) = 0;
+
+  virtual queue_metrics_t get_qmetrics(bool bReset = false) = 0;
 };
 
 } // namespace srslte

--- a/lib/include/srslte/upper/rlc_metrics.h
+++ b/lib/include/srslte/upper/rlc_metrics.h
@@ -28,14 +28,25 @@
 #define SRSLTE_RLC_METRICS_H
 
 #include "srslte/common/common.h"
+#include "srslte/common/queue_metrics.h"
+#include "srslte/upper/rlc_interface.h"
 
 namespace srslte {
+
+struct rlc_queue_metrics_t { 
+ queue_metrics_t qmetrics;
+ rlc_mode_t      mode;
+};
+
 
 struct rlc_metrics_t
 {
   float dl_tput_mbps[SRSLTE_N_RADIO_BEARERS];
   float ul_tput_mbps[SRSLTE_N_RADIO_BEARERS];
   float dl_tput_mrb_mbps[SRSLTE_N_MCH_LCIDS];
+
+  rlc_queue_metrics_t metrics[SRSLTE_N_MCH_LCIDS];
+  rlc_queue_metrics_t mrb_metrics[SRSLTE_N_MCH_LCIDS];
 };
 
 } // namespace srslte

--- a/lib/include/srslte/upper/rlc_tm.h
+++ b/lib/include/srslte/upper/rlc_tm.h
@@ -67,6 +67,7 @@ public:
   int      read_pdu(uint8_t *payload, uint32_t nof_bytes);
   void     write_pdu(uint8_t *payload, uint32_t nof_bytes);
 
+  queue_metrics_t get_qmetrics(bool bReset);
 private:
 
   byte_buffer_pool          *pool;

--- a/lib/include/srslte/upper/rlc_tx_queue.h
+++ b/lib/include/srslte/upper/rlc_tx_queue.h
@@ -110,6 +110,10 @@ public:
     unread_bytes = 0;
   }
 
+  queue_metrics_t get_qmetrics(bool bReset) {
+    return queue.get_qmetrics(bReset);
+  }
+
 private:
   bool                        is_empty() { return queue.empty(); }
 

--- a/lib/include/srslte/upper/rlc_um.h
+++ b/lib/include/srslte/upper/rlc_um.h
@@ -78,6 +78,7 @@ public:
   uint32_t get_num_rx_bytes();
   void reset_metrics();
 
+  queue_metrics_t get_qmetrics(bool bReset);
 private:
 
   // Transmitter sub-class
@@ -97,6 +98,7 @@ private:
     uint32_t get_num_tx_bytes();
     void reset_metrics();
     uint32_t get_buffer_size_bytes();
+    queue_metrics_t get_qmetrics(bool bReset);
 
   private:
     byte_buffer_pool        *pool;

--- a/lib/src/upper/rlc.cc
+++ b/lib/src/upper/rlc.cc
@@ -122,18 +122,26 @@ void rlc::get_metrics(rlc_metrics_t &m)
   for (rlc_map_t::iterator it = rlc_array.begin(); it != rlc_array.end(); ++it) {
     m.dl_tput_mbps[it->first] = (it->second->get_num_rx_bytes()*8/static_cast<double>(1e6))/secs;
     m.ul_tput_mbps[it->first] = (it->second->get_num_tx_bytes()*8/static_cast<double>(1e6))/secs;
-    rlc_log->info("LCID=%d, RX throughput: %4.6f Mbps. TX throughput: %4.6f Mbps.\n",
+    m.metrics[it->first].qmetrics = it->second->get_qmetrics();
+    m.metrics[it->first].mode = it->second->get_mode();
+    rlc_log->info("LCID=%d, RX throughput: %4.6f Mbps. TX throughput: %4.6f Mbps. mode %s, %s\n",
                     it->first,
                     (it->second->get_num_rx_bytes()*8/static_cast<double>(1e6))/secs,
-                    (it->second->get_num_tx_bytes()*8/static_cast<double>(1e6))/secs);
+                    (it->second->get_num_tx_bytes()*8/static_cast<double>(1e6))/secs,
+                    rlc_mode_text[it->second->get_mode()],
+                    m.metrics[it->first].qmetrics.toString().c_str());
   }
 
   // Add multicast metrics
   for (rlc_map_t::iterator it = rlc_array_mrb.begin(); it != rlc_array_mrb.end(); ++it) {
     m.dl_tput_mbps[it->first] = (it->second->get_num_rx_bytes()*8/static_cast<double>(1e6))/secs;
-    rlc_log->info("MCH_LCID=%d, RX throughput: %4.6f Mbps\n",
+    m.mrb_metrics[it->first].qmetrics = it->second->get_qmetrics();
+    m.metrics[it->first].mode = it->second->get_mode();
+    rlc_log->info("MCH_LCID=%d, RX throughput: %4.6f Mbps. mode %s, %s\n",
                   it->first,
-                  (it->second->get_num_rx_bytes()*8/static_cast<double>(1e6))/secs);
+                  (it->second->get_num_rx_bytes()*8/static_cast<double>(1e6))/secs,
+                  rlc_mode_text[it->second->get_mode()],
+                  m.metrics[it->first].qmetrics.toString().c_str());
   }
 
   memcpy(&metrics_time[1], &metrics_time[2], sizeof(struct timeval));

--- a/lib/src/upper/rlc_am.cc
+++ b/lib/src/upper/rlc_am.cc
@@ -139,6 +139,11 @@ void rlc_am::reset_metrics()
   rx.reset_metrics();
 }
 
+queue_metrics_t rlc_am::get_qmetrics(bool bReset)
+{
+  return tx.get_qmetrics(bReset);
+}
+
 /****************************************************************************
  * PDCP interface
  ***************************************************************************/
@@ -1194,7 +1199,10 @@ bool rlc_am::rlc_am_tx::retx_queue_has_sn(uint32_t sn)
   return false;
 }
 
-
+queue_metrics_t rlc_am::rlc_am_tx::get_qmetrics(bool bReset)
+{
+  return tx_sdu_queue.get_qmetrics(bReset);
+}
 
 /****************************************************************************
  * Rx subclass implementation

--- a/lib/src/upper/rlc_tm.cc
+++ b/lib/src/upper/rlc_tm.cc
@@ -192,4 +192,9 @@ void rlc_tm::write_pdu(uint8_t *payload, uint32_t nof_bytes)
   }
 }
 
+queue_metrics_t rlc_tm::get_qmetrics(bool bReset)
+{
+  return ul_queue.get_qmetrics(bReset);
+}
+
 } // namespace srsue

--- a/lib/src/upper/rlc_um.cc
+++ b/lib/src/upper/rlc_um.cc
@@ -198,6 +198,10 @@ void rlc_um::reset_metrics()
   rx.reset_metrics();
 }
 
+queue_metrics_t rlc_um::get_qmetrics(bool bReset)
+{
+  return tx.get_qmetrics(bReset);
+}
 
 /****************************************************************************
  * Helper functions
@@ -502,6 +506,12 @@ const char* rlc_um::rlc_um_tx::get_rb_name()
 void rlc_um::rlc_um_tx::debug_state()
 {
   log->debug("%s vt_us = %d\n", get_rb_name(), vt_us);
+}
+
+
+queue_metrics_t rlc_um::rlc_um_tx::get_qmetrics(bool bReset)
+{
+  return tx_sdu_queue.get_qmetrics(bReset);
 }
 
 /****************************************************************************

--- a/srsenb/hdr/upper/rlc.h
+++ b/srsenb/hdr/upper/rlc.h
@@ -28,6 +28,7 @@
 #include "srslte/interfaces/ue_interfaces.h"
 #include "srslte/interfaces/enb_interfaces.h"
 #include "srslte/upper/rlc.h"
+#include "srslte/upper/rlc_metrics.h"
 
 #ifndef SRSENB_RLC_H
 #define SRSENB_RLC_H
@@ -70,6 +71,8 @@ public:
   void write_pdu(uint16_t rnti, uint32_t lcid, uint8_t *payload, uint32_t nof_bytes);
   void read_pdu_pcch(uint8_t *payload, uint32_t buffer_size); 
   
+  void get_metrics(srslte::rlc_metrics_t &m);
+
 private: 
   
   class user_interface : public srsue::pdcp_interface_rlc, 

--- a/srsenb/src/enb.cc
+++ b/srsenb/src/enb.cc
@@ -303,6 +303,7 @@ bool enb::get_metrics(enb_metrics_t &m)
   mac.get_metrics(m.mac);
   rrc.get_metrics(m.rrc);
   s1ap.get_metrics(m.s1ap);
+  rlc.get_metrics(m.rlc);
 
   m.running = started;  
   return true;

--- a/srsenb/src/upper/rlc.cc
+++ b/srsenb/src/upper/rlc.cc
@@ -248,4 +248,14 @@ std::string rlc::user_interface::get_rb_name(uint32_t lcid)
   return std::string(rb_id_text[lcid]);
 }
 
+void rlc::get_metrics(srslte::rlc_metrics_t &m)
+{
+  pthread_rwlock_rdlock(&rwlock);
+  for(std::map<uint32_t, user_interface>::iterator iter=users.begin(); iter!=users.end(); ++iter) {
+    iter->second.rlc->get_metrics(m);
+  }
+  pthread_rwlock_unlock(&rwlock);
+}
+
+
 }


### PR DESCRIPTION
added push, pop, capacity, highwater, failures and clear counts to block_queue.
incorporated these into the rlc metrics.

```
LCID=0, RX throughput: 0.000000 Mbps. TX throughput: 0.000000 Mbps. mode Transparent Mode, cs=0, hw=1, cap=16, nc=0, npu=1, npuf=0, npo=1, npof=0
LCID=1, RX throughput: 0.000000 Mbps. TX throughput: 0.000000 Mbps. mode Acknowledged Mode, cs=0, hw=2, cap=128, nc=0, npu=7, npuf=0, npo=7, npof=0
LCID=2, RX throughput: 0.000000 Mbps. TX throughput: 0.000000 Mbps. mode Acknowledged Mode, cs=0, hw=0, cap=128, nc=0, npu=0, npuf=0, npo=0, npof=0
LCID=3, RX throughput: 0.000000 Mbps. TX throughput: 0.078584 Mbps. mode Unacknowledged Mode, cs=0, hw=1, cap=128, nc=0, npu=294, npuf=0, npo=294, npof=0
```