### PR TITLE
Remove undefined increment of an erased iterator.

### DIFF
--- a/lib/src/upper/pdcp.cc
+++ b/lib/src/upper/pdcp.cc
@@ -93,10 +93,10 @@ void pdcp::reset()
 {
   // destroy all bearers
   pthread_rwlock_wrlock(&rwlock);
-  for (pdcp_map_t::iterator it = pdcp_array.begin(); it != pdcp_array.end(); ++it) {
+  for (pdcp_map_t::iterator it = pdcp_array.begin(); it != pdcp_array.end(); /* post increment in erase */ ) {
     it->second->reset();
     delete(it->second);
-    pdcp_array.erase(it);
+    pdcp_array.erase(it++);
   }
   pthread_rwlock_unlock(&rwlock);
 


### PR DESCRIPTION
The block of code calls an erase on an iterator controlling the for loop, which invalidates the iterator. After the first iteration of the loop, the post-increment on the iterator inside the for statement is not guaranteed to work - on Fedora 29 it causes a segfault. Move the iterator increment operation to a post-increment inside the call to erase.