### PR TITLE
Fixed the crash when pdsch_enodeb used in diversity mode

### DIFF
--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -191,7 +191,7 @@ void rf_soapy_register_error_handler(void *h, srslte_rf_error_handler_t new_hand
 char* rf_soapy_devname(void* h)
 {
   rf_soapy_handler_t *handler = (rf_soapy_handler_t*) h;
-  return handler->devname; 
+  return handler->devname;
 }
 
 
@@ -235,7 +235,7 @@ int rf_soapy_start_tx_stream(void *h)
   if(handler->tx_stream_active == false){
     if(SoapySDRDevice_activateStream(handler->device, handler->txStream, 0, 0, 0) != 0)
       return SRSLTE_ERROR;
-    handler->tx_stream_active = true;  
+    handler->tx_stream_active = true;
    }
   return SRSLTE_SUCCESS;
 }
@@ -246,7 +246,7 @@ int rf_soapy_stop_rx_stream(void *h)
   rf_soapy_handler_t *handler = (rf_soapy_handler_t*) h;
   if (SoapySDRDevice_deactivateStream(handler->device, handler->rxStream, 0, 0) != 0)
     return SRSLTE_ERROR;
-  
+
   handler->rx_stream_active = false;
   return SRSLTE_SUCCESS;
 }
@@ -294,7 +294,7 @@ int rf_soapy_open_multi(char *args, void **h, uint32_t nof_rx_antennas)
 {
   size_t length;
   const SoapySDRKwargs *soapy_args = SoapySDRDevice_enumerate(NULL, &length);
-  
+
   if (length == 0) {
     printf("No Soapy devices found.\n");
     return SRSLTE_ERROR;
@@ -312,13 +312,13 @@ int rf_soapy_open_multi(char *args, void **h, uint32_t nof_rx_antennas)
     }
     printf("\n");
   }
-  
+
   SoapySDRDevice *sdr = SoapySDRDevice_make(&(soapy_args[0]));
   if (sdr == NULL) {
     printf("Failed to create Soapy object\n");
     return SRSLTE_ERROR;
   }
-  
+
   // create handler
   rf_soapy_handler_t *handler = (rf_soapy_handler_t*) malloc(sizeof(rf_soapy_handler_t));
   bzero(handler, sizeof(rf_soapy_handler_t));
@@ -457,8 +457,10 @@ int rf_soapy_open_multi(char *args, void **h, uint32_t nof_rx_antennas)
     rf_soapy_set_rx_gain(handler, 35);
 
     cf_t dummy_buffer[1920];
+    cf_t dummy_buffer1[1920];
     cf_t *dummy_buffer_array[SRSLTE_MAX_PORTS];
     dummy_buffer_array[0] = dummy_buffer;
+    dummy_buffer_array[1] = dummy_buffer1;
     rf_soapy_start_rx_stream(handler, true);
     rf_soapy_recv_with_time_multi(handler, (void**)dummy_buffer_array, 1920, false, NULL, NULL);
     rf_soapy_stop_rx_stream(handler);
@@ -523,7 +525,7 @@ int rf_soapy_close(void *h)
     rf_soapy_stop_tx_stream(handler);
     SoapySDRDevice_closeStream(handler->device, handler->txStream);
   }
-  
+
   if (handler->rx_stream_active) {
     rf_soapy_stop_rx_stream(handler);
     SoapySDRDevice_closeStream(handler->device, handler->rxStream);
@@ -731,9 +733,9 @@ int  rf_soapy_recv_with_time_multi(void *h,
 {
   rf_soapy_handler_t *handler = (rf_soapy_handler_t*) h;
   int flags; //flags set by receive operation
-  int num_channels = 1; // temp
+  int num_channels = 2; // temp
   const long timeoutUs = 400000; // arbitrarily chosen
-  
+
   int trials = 0;
   int ret = 0;
   long long timeNs; //timestamp for receive buffer


### PR DESCRIPTION
When trying to achieve TX on 2 Channel, got crashed and this would be quick fix, however there are some comments on code that multi channel mode is in TODO list. May be fixed if possible.