### PR TITLE
Fallback to AVX2 if AVX512 functions are not support

### DIFF
--- a/lib/include/srslte/phy/utils/simd.h
+++ b/lib/include/srslte/phy/utils/simd.h
@@ -1341,7 +1341,7 @@ static inline simd_s_t srslte_simd_s_mul(simd_s_t a, simd_s_t b) {
 
 static inline simd_s_t srslte_simd_s_neg(simd_s_t a, simd_s_t b) {
 #ifdef LV_HAVE_AVX512
-#error sign instruction not available in avx512
+#warning sign instruction not available in avx512. fallback to avx2
 #else /* LV_HAVE_AVX512 */
 #ifdef LV_HAVE_AVX2
   return _mm256_sign_epi16(a, b);
@@ -1814,7 +1814,7 @@ static inline simd_s_t srslte_simd_b_sub(simd_s_t a, simd_s_t b) {
 
 static inline simd_s_t srslte_simd_b_neg(simd_b_t a, simd_b_t b) {
 #ifdef LV_HAVE_AVX512
-#error sign instruction not available in avx512
+#warning sign instruction not available in avx512. fallback to avx2
 #else /* LV_HAVE_AVX512 */
 #ifdef LV_HAVE_AVX2
   return _mm256_sign_epi8(a, b);


### PR DESCRIPTION
Hi,

changing the AVX512 errors to warning helps to compile, even if some functions are not AVX512 supported. We now simple downgrade the function to a AVX2 function.

Best regards,
David
