### PR TITLE
Change scheduler_ue get_aggr_level to use current_cfi as the upper limit

### DIFF
--- a/srsenb/hdr/mac/scheduler_ue.h
+++ b/srsenb/hdr/mac/scheduler_ue.h
@@ -130,7 +130,7 @@ public:
   int        generate_format0(ul_harq_proc *h, sched_interface::ul_sched_data_t *data, uint32_t tti, bool cqi_request);
 
   srslte_dci_format_t get_dci_format();
-  uint32_t         get_aggr_level(uint32_t nof_bits);
+  uint32_t         get_aggr_level(uint32_t nof_bits, uint32_t current_cfi);
   sched_dci_cce_t *get_locations(uint32_t current_cfi, uint32_t sf_idx);
   
   bool       needs_cqi(uint32_t tti, bool will_send = false); 

--- a/srsenb/src/mac/scheduler.cc
+++ b/srsenb/src/mac/scheduler.cc
@@ -698,7 +698,7 @@ int sched::dl_sched_data(dl_sched_data_t data[MAX_DATA_LIST])
     srslte_dci_format_t dci_format = user->get_dci_format();
     data[nof_data_elems].dci_format = dci_format;
 
-    uint32_t aggr_level = user->get_aggr_level(srslte_dci_format_sizeof(SRSLTE_DCI_FORMAT1, cfg.cell.nof_prb, cfg.cell.nof_ports));
+    uint32_t aggr_level = user->get_aggr_level(srslte_dci_format_sizeof(SRSLTE_DCI_FORMAT1, cfg.cell.nof_prb, cfg.cell.nof_ports), current_cfi);
     if (h) {
       // Try to schedule DCI first 
       if (generate_dci(&data[nof_data_elems].dci_location, 
@@ -945,7 +945,7 @@ int sched::ul_sched(uint32_t tti, srsenb::sched_interface::ul_sched_res_t* sched
 
       // Generate PDCCH except for RAR and non-adaptive retx
       if (needs_pdcch) {
-        uint32_t aggr_level = user->get_aggr_level(srslte_dci_format_sizeof(SRSLTE_DCI_FORMAT0, cfg.cell.nof_prb, cfg.cell.nof_ports));
+        uint32_t aggr_level = user->get_aggr_level(srslte_dci_format_sizeof(SRSLTE_DCI_FORMAT0, cfg.cell.nof_prb, cfg.cell.nof_ports), current_cfi);
         if (!generate_dci(&sched_result->pusch[nof_dci_elems].dci_location, 
             user->get_locations(current_cfi, sf_idx),
             aggr_level)) 

--- a/srsenb/src/mac/scheduler_ue.cc
+++ b/srsenb/src/mac/scheduler_ue.cc
@@ -1083,14 +1083,14 @@ srslte_dci_format_t sched_ue::get_dci_format() {
 
 
 /* Find lowest DCI aggregation level supported by the UE spectral efficiency */
-uint32_t sched_ue::get_aggr_level(uint32_t nof_bits)
+uint32_t sched_ue::get_aggr_level(uint32_t nof_bits, uint32_t current_cfi)
 {
   pthread_mutex_lock(&mutex);
   uint32_t l=0;
   float max_coderate = srslte_cqi_to_coderate(dl_cqi);
   float coderate = 99;
   float factor=1.5;
-  uint32_t l_max = 3;
+  uint32_t l_max = current_cfi;
   if (cell.nof_prb == 6) {
     factor = 1.0;
     l_max  = 2;


### PR DESCRIPTION
Change scheduler_ue get_aggr_level to use current_cfi as the upper limit for determining the pdcch aggregation level. This prevents the calculation result from exceeding the configured nof_ctrl_symbols.