### PR TITLE
Unable to set master clock rate on type x300 

### DIFF
--- a/lib/src/phy/rf/rf_uhd_imp.c
+++ b/lib/src/phy/rf/rf_uhd_imp.c
@@ -439,7 +439,6 @@ int rf_uhd_open_multi(char *args, void **h, uint32_t nof_channels)
           if (strstr(args, "master_clock_rate=184.32e6")) {
             handler->current_master_clock = 184320000;
           } else if (strstr(args, "master_clock_rate=200.0e6") || strstr(args, "master_clock_rate=200.00e6")){
-            sprintf(args2, "%s,master_clock_rate=184.32e6", args);
             handler->current_master_clock = 200000000;
           } else {
             if (strstr(args, "master_clock_rate")) fprintf(stderr,"No such master_clock_rate for x300\n");

--- a/lib/src/phy/rf/rf_uhd_imp.c
+++ b/lib/src/phy/rf/rf_uhd_imp.c
@@ -434,12 +434,20 @@ int rf_uhd_open_multi(char *args, void **h, uint32_t nof_channels)
       }
     } else {
       // If args is set and x300 type is specified, make sure master_clock_rate is defined
-      if (strstr(args, "type=x300") && !strstr(args, "master_clock_rate")) {
-        sprintf(args2, "%s,master_clock_rate=184.32e6",args);
-        args = args2;
-        handler->current_master_clock = 184320000;
-        handler->dynamic_rate = false;
-        handler->devname = DEVNAME_X300;
+        if (strstr(args, "type=x300") ){
+          //x300 only has 2 possible master clocks 184.32e6 and 200.0e6
+          if (strstr(args, "master_clock_rate=184.32e6")) {
+            handler->current_master_clock = 184320000;
+          } else if (strstr(args, "master_clock_rate=200.0e6") || strstr(args, "master_clock_rate=200.00e6")){
+            sprintf(args2, "%s,master_clock_rate=184.32e6", args);
+            handler->current_master_clock = 200000000;
+          } else {
+            if (strstr(args, "master_clock_rate")) fprintf(stderr,"No such master_clock_rate for x300\n");
+            sprintf(args2, "%s,master_clock_rate=184.32e6", args);
+            args = args2;
+          }
+          handler->dynamic_rate = false;
+          handler->devname = DEVNAME_X300;
       } else if (strstr(args, "type=n3xx")) {
         sprintf(args2, "%s,master_clock_rate=122.88e6", args);
         args = args2;


### PR DESCRIPTION
Hello, 
We are running srslte with an x300. 
When trying to set the master clock rate to 182.32e6 we noticed that the master clock rate was set to a default 30.72e6 and not the value that we were specifing in our enb.conf.
`device_args = type=x300,master_clock_rate=184.32e6,recv_frame_size=8000,send_frame_size=8000`
```bash
linux; GNU C++ version 5.3.1 20151219; Boost_105800; UHD_003.009.002-0-unknown


Built in Release mode using commit a4a7354 on branch master.
---  Software Radio Systems LTE eNodeB  ---

Reading configuration file enb.conf...
Opening USRP with args: 
>>>  type=x300,master_clock_rate=30.72e6,master_clock_rate=184.32e6
-- X300 initialization sequence...
-- Determining maximum frame size... 8000 bytes.
-- Setup basic communication...
-- Loading values from EEPROM...
-- Setup RF frontend clocking...
```
The work around we found of getting 184.32e6 clock rate was to not specify the clock rate in the configuration file and let it be set as a default for a type x300. Additionally it would seem that providing a `type=x300` in conjunction with any value of `master_clock_rate` results in the device being seen as an b200 [link to C](https://github.com/srsLTE/srsLTE/blob/61f3a55bc5b83f12918ad81beb05b20793f61c51/lib/src/phy/rf/rf_uhd_imp.c#L458)
```C
        handler->devname = DEVNAME_B200;
```

We would like to suggest a solution if what we have identified turns out to actually be a minor bug.
Have a nice day, and a great fosdem.