### PR TITLE
Fixed check for valid cell-identity group

### DIFF
--- a/lib/src/phy/common/phy_common.c
+++ b/lib/src/phy/common/phy_common.c
@@ -117,7 +117,7 @@ bool srslte_N_id_2_isvalid(uint32_t N_id_2) {
 }
 
 bool srslte_N_id_1_isvalid(uint32_t N_id_1) {
-  if (N_id_1 < 169) {
+  if (N_id_1 < 168) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
According to 36.211 section 6.11 the physical-layer cell-identity groups(N_id_1)  only range from 0 to 167.