### PR TITLE
Enb up encryption

### DIFF
--- a/lib/include/srslte/asn1/liblte_s1ap.h
+++ b/lib/include/srslte/asn1/liblte_s1ap.h
@@ -1352,7 +1352,7 @@ LIBLTE_ERROR_ENUM liblte_s1ap_unpack_enbname(
 #define LIBLTE_S1AP_ENCRYPTIONALGORITHMS_BIT_STRING_LEN 16
 typedef struct{
   bool     ext;
-  uint8_t  buffer[16];
+  uint8_t  buffer[LIBLTE_S1AP_ENCRYPTIONALGORITHMS_BIT_STRING_LEN];
 }LIBLTE_S1AP_ENCRYPTIONALGORITHMS_STRUCT;
 
 LIBLTE_ERROR_ENUM liblte_s1ap_pack_encryptionalgorithms(
@@ -2775,7 +2775,7 @@ LIBLTE_ERROR_ENUM liblte_s1ap_unpack_handovertype(
 #define LIBLTE_S1AP_INTEGRITYPROTECTIONALGORITHMS_BIT_STRING_LEN 16
 typedef struct{
   bool     ext;
-  uint8_t  buffer[16];
+  uint8_t  buffer[LIBLTE_S1AP_INTEGRITYPROTECTIONALGORITHMS_BIT_STRING_LEN];
 }LIBLTE_S1AP_INTEGRITYPROTECTIONALGORITHMS_STRUCT;
 
 LIBLTE_ERROR_ENUM liblte_s1ap_pack_integrityprotectionalgorithms(

--- a/lib/include/srslte/interfaces/enb_interfaces.h
+++ b/lib/include/srslte/interfaces/enb_interfaces.h
@@ -200,6 +200,7 @@ public:
                                uint32_t lcid,
                                uint8_t *k_rrc_enc_,
                                uint8_t *k_rrc_int_,
+                               uint8_t *k_up_enc_,
                                srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                                srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_) = 0;
 };

--- a/lib/include/srslte/interfaces/enb_interfaces.h
+++ b/lib/include/srslte/interfaces/enb_interfaces.h
@@ -203,6 +203,8 @@ public:
                                uint8_t *k_up_enc_,
                                srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                                srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_) = 0;
+  virtual void enable_integrity(uint16_t rnti, uint32_t lcid) = 0;
+  virtual void enable_encryption(uint16_t rnti, uint32_t lcid) = 0;
 };
 
 // PDCP interface for RLC

--- a/lib/include/srslte/interfaces/ue_interfaces.h
+++ b/lib/include/srslte/interfaces/ue_interfaces.h
@@ -244,12 +244,14 @@ public:
   virtual void add_bearer(uint32_t lcid, srslte::srslte_pdcp_config_t cnfg = srslte::srslte_pdcp_config_t()) = 0;
   virtual void change_lcid(uint32_t old_lcid, uint32_t new_lcid) = 0;
   virtual void config_security(uint32_t lcid,
-                               uint8_t *k_enc_,
-                               uint8_t *k_int_,
+                               uint8_t *k_rrc_enc_,
+                               uint8_t *k_rrc_int_,
+                               uint8_t *k_up_enc_,
                                srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                                srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_) = 0;
-  virtual void config_security_all(uint8_t *k_enc_,
-                                   uint8_t *k_int_,
+  virtual void config_security_all(uint8_t *k_rrc_enc_,
+                                   uint8_t *k_rrc_int_,
+                                   uint8_t *k_up_enc_,
                                    srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                                    srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_) = 0;
   virtual void enable_integrity(uint32_t lcid) = 0;

--- a/lib/include/srslte/upper/pdcp.h
+++ b/lib/include/srslte/upper/pdcp.h
@@ -63,12 +63,14 @@ public:
   void del_bearer(uint32_t lcid);
   void change_lcid(uint32_t old_lcid, uint32_t new_lcid);
   void config_security(uint32_t lcid,
-                       uint8_t *k_enc,
-                       uint8_t *k_int,
+                       uint8_t *k_rrc_enc,
+                       uint8_t *k_rrc_int,
+                       uint8_t *k_up_enc,
                        CIPHERING_ALGORITHM_ID_ENUM cipher_algo,
                        INTEGRITY_ALGORITHM_ID_ENUM integ_algo);
-  void config_security_all(uint8_t *k_enc,
-                           uint8_t *k_int,
+  void config_security_all(uint8_t *k_rrc_enc,
+                           uint8_t *k_rrc_int,
+                           uint8_t *k_up_enc,
                            CIPHERING_ALGORITHM_ID_ENUM cipher_algo,
                            INTEGRITY_ALGORITHM_ID_ENUM integ_algo);
   void enable_integrity(uint32_t lcid);

--- a/lib/include/srslte/upper/pdcp_entity.h
+++ b/lib/include/srslte/upper/pdcp_entity.h
@@ -78,8 +78,9 @@ public:
 
   // RRC interface
   void write_sdu(byte_buffer_t *sdu, bool blocking);
-  void config_security(uint8_t *k_enc_,
-                       uint8_t *k_int_,
+  void config_security(uint8_t *k_rrc_enc_,
+                       uint8_t *k_rrc_int_,
+                       uint8_t *k_up_enc_,
                        CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                        INTEGRITY_ALGORITHM_ID_ENUM integ_algo_);
   void enable_integrity();
@@ -107,9 +108,10 @@ private:
 
   uint32_t            rx_count;
   uint32_t            tx_count;
-  uint8_t             k_enc[32];
-  uint8_t             k_int[32];
-
+  uint8_t             k_rrc_enc[32];
+  uint8_t             k_rrc_int[32];
+  uint8_t             k_up_enc[32];
+  
   CIPHERING_ALGORITHM_ID_ENUM cipher_algo;
   INTEGRITY_ALGORITHM_ID_ENUM integ_algo;
 

--- a/lib/include/srslte/upper/pdcp_interface.h
+++ b/lib/include/srslte/upper/pdcp_interface.h
@@ -56,8 +56,9 @@ public:
 
   // RRC interface
   virtual void write_sdu(byte_buffer_t *sdu, bool blocking) = 0;
-  virtual void config_security(uint8_t *k_enc_,
-                       uint8_t *k_int_,
+  virtual void config_security(uint8_t *k_rrc_enc_,
+                       uint8_t *k_rrc_int_,
+                       uint8_t *k_up_enc_,
                        CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                        INTEGRITY_ALGORITHM_ID_ENUM integ_algo_) = 0;
   virtual void enable_integrity() = 0;

--- a/lib/src/upper/pdcp.cc
+++ b/lib/src/upper/pdcp.cc
@@ -216,26 +216,25 @@ exit:
 }
 
 void pdcp::config_security(uint32_t lcid,
-                           uint8_t *k_enc,
-                           uint8_t *k_int,
+                           uint8_t *k_rrc_enc,
+                           uint8_t *k_rrc_int,
+                           uint8_t *k_up_enc,
                            CIPHERING_ALGORITHM_ID_ENUM cipher_algo,
                            INTEGRITY_ALGORITHM_ID_ENUM integ_algo)
 {
   pthread_rwlock_rdlock(&rwlock);
   if (valid_lcid(lcid)) {
-    pdcp_array.at(lcid)->config_security(k_enc, k_int, cipher_algo, integ_algo);
+    pdcp_array.at(lcid)->config_security(k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
   }
   pthread_rwlock_unlock(&rwlock);
 }
 
-void pdcp::config_security_all(uint8_t *k_enc,
-                               uint8_t *k_int,
-                               CIPHERING_ALGORITHM_ID_ENUM cipher_algo,
-                               INTEGRITY_ALGORITHM_ID_ENUM integ_algo)
+void pdcp::config_security_all(uint8_t* k_rrc_enc, uint8_t* k_rrc_int, uint8_t* k_up_enc,
+                               CIPHERING_ALGORITHM_ID_ENUM cipher_algo, INTEGRITY_ALGORITHM_ID_ENUM integ_algo)
 {
   pthread_rwlock_rdlock(&rwlock);
   for (pdcp_map_t::iterator it = pdcp_array.begin(); it != pdcp_array.end(); ++it) {
-    it->second->config_security(k_enc, k_int, cipher_algo, integ_algo);
+    it->second->config_security(k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
   }
   pthread_rwlock_unlock(&rwlock);
 }

--- a/lib/src/upper/pdcp_entity.cc
+++ b/lib/src/upper/pdcp_entity.cc
@@ -85,7 +85,7 @@ void pdcp_entity::init(srsue::rlc_interface_pdcp      *rlc_,
     sn_len_bytes = 2;
   }
 
-  log->debug("Init %s\n", rrc->get_rb_name(lcid).c_str());
+  log->info("Init %s with bearer ID: %d\n", rrc->get_rb_name(lcid).c_str(), cfg.bearer_id);
 }
 
 // Reestablishment procedure: 36.323 5.2
@@ -205,7 +205,7 @@ void pdcp_entity::write_pdu(byte_buffer_t *pdu)
                      rx_count,
                      pdu->N_bytes - sn_len_bytes,
                      &(pdu->msg[sn_len_bytes]));
-      log->info_hex(pdu->msg, pdu->N_bytes, "RX %s PDU (decrypted)", rrc->get_rb_name(lcid).c_str());
+      log->debug_hex(pdu->msg, pdu->N_bytes, "RX %s PDU (decrypted)", rrc->get_rb_name(lcid).c_str());
     }
     if(12 == cfg.sn_len)
     {

--- a/srsenb/enb.conf.example
+++ b/srsenb/enb.conf.example
@@ -155,6 +155,8 @@ nof_ctrl_symbols = 3
 # enable_mbsfn:         Enable MBMS transmission in the eNB
 # m1u_multiaddr:        Multicast addres the M1-U socket will register to
 # m1u_if_addr:          Address of the inteferface the M1-U interface will listen for multicast packets.
+# eea_pref_list:        Ordered preference list for the selection of encryption algorithm (EEA) (default: EEA0, EEA2, EEA1). 
+# eia_pref_list:        Ordered preference list for the selection of integrity algorithm (EIA) (default: EIA2, EIA1, EIA0).
 #
 #####################################################################
 [expert]
@@ -172,3 +174,5 @@ nof_ctrl_symbols = 3
 #enable_mbsfn = false
 #m1u_multiaddr = 239.255.0.1
 #m1u_if_addr = 127.0.1.201 
+#eea_pref_list = EEA0, EEA2, EEA1
+#eia_pref_list = EIA2, EIA1, EIA0

--- a/srsenb/hdr/enb.h
+++ b/srsenb/hdr/enb.h
@@ -47,6 +47,7 @@
 
 #include "srslte/radio/radio.h"
 
+#include "srslte/common/security.h"
 #include "srslte/common/bcd_helpers.h"
 #include "srslte/common/buffer_pool.h"
 #include "srslte/interfaces/ue_interfaces.h"
@@ -132,6 +133,8 @@ typedef struct {
   bool        print_buffer_state;
   std::string m1u_multiaddr;
   std::string m1u_if_addr;
+  std::string eia_pref_list;
+  std::string eea_pref_list;
 }expert_args_t;
 
 typedef struct { 

--- a/srsenb/hdr/upper/pdcp.h
+++ b/srsenb/hdr/upper/pdcp.h
@@ -57,6 +57,7 @@ public:
                        uint32_t lcid,
                        uint8_t *k_rrc_enc_,
                        uint8_t *k_rrc_int_,
+                       uint8_t *k_up_enc_,
                        srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                        srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_);
   

--- a/srsenb/hdr/upper/pdcp.h
+++ b/srsenb/hdr/upper/pdcp.h
@@ -60,7 +60,8 @@ public:
                        uint8_t *k_up_enc_,
                        srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                        srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_);
-  
+  void enable_integrity(uint16_t rnti, uint32_t lcid);
+  void enable_encryption(uint16_t rnti, uint32_t lcid);
 private: 
   
   class user_interface_rlc : public srsue::rlc_interface_pdcp

--- a/srsenb/hdr/upper/rrc.h
+++ b/srsenb/hdr/upper/rrc.h
@@ -337,7 +337,8 @@ private:
                           uint8_t *k_up_int,
                           srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo,
                           srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo);
-
+  void enable_integrity(uint16_t rnti, uint32_t lcid);
+  void enable_encryption(uint16_t rnti, uint32_t lcid);
   srslte::byte_buffer_pool* pool;
   srslte::byte_buffer_t     byte_buf_paging;
 

--- a/srsenb/hdr/upper/rrc.h
+++ b/srsenb/hdr/upper/rrc.h
@@ -245,6 +245,7 @@ public:
     void cqi_get(uint16_t* pmi_idx, uint16_t* n_pucch);
     int  cqi_free();
 
+    bool select_security_algorithms();
     void send_dl_ccch(asn1::rrc::dl_ccch_msg_s* dl_ccch_msg);
     void send_dl_dcch(asn1::rrc::dl_dcch_msg_s* dl_dcch_msg, srslte::byte_buffer_t* pdu = NULL);
 

--- a/srsenb/hdr/upper/rrc.h
+++ b/srsenb/hdr/upper/rrc.h
@@ -90,7 +90,11 @@ typedef struct {
   srslte_cell_t                      cell;
   bool                               enable_mbsfn;
   uint32_t                           inactivity_timeout_ms;
-}rrc_cfg_t; 
+  srslte::CIPHERING_ALGORITHM_ID_ENUM
+      eea_preference_list[srslte::CIPHERING_ALGORITHM_ID_N_ITEMS];
+  srslte::INTEGRITY_ALGORITHM_ID_ENUM
+      eia_preference_list[srslte::INTEGRITY_ALGORITHM_ID_N_ITEMS];
+} rrc_cfg_t;
 
 static const char rrc_state_text[RRC_STATE_N_ITEMS][100] = {"IDLE",
                                                             "WAIT FOR CON SETUP COMPLETE",

--- a/srsenb/src/enb.cc
+++ b/srsenb/src/enb.cc
@@ -179,6 +179,56 @@ bool enb::init(all_args_t *args_)
   rrc_cfg.inactivity_timeout_ms = args->expert.rrc_inactivity_timer;
   rrc_cfg.enable_mbsfn          = args->expert.enable_mbsfn;
 
+  // Parse EEA preference list
+  std::vector<std::string> eea_pref_list;
+  boost::split(eea_pref_list, args->expert.eea_pref_list,
+               boost::is_any_of(","));
+  int i = 0;
+  for (std::vector<std::string>::iterator it = eea_pref_list.begin();
+       it != eea_pref_list.end() && i < srslte::CIPHERING_ALGORITHM_ID_N_ITEMS;
+       it++) {
+    boost::trim_left(*it);
+    if ((*it).compare("EEA0") == 0) {
+      rrc_cfg.eea_preference_list[i] = srslte::CIPHERING_ALGORITHM_ID_EEA0;
+      i++;
+    } else if ((*it).compare("EEA1") == 0) {
+      rrc_cfg.eea_preference_list[i] = srslte::CIPHERING_ALGORITHM_ID_128_EEA1;
+      i++;
+    } else if ((*it).compare("EEA2") == 0) {
+      rrc_cfg.eea_preference_list[i] = srslte::CIPHERING_ALGORITHM_ID_128_EEA2;
+      i++;
+    } else {
+      fprintf(stderr, "Failed to parse EEA prefence list %s \n",
+              args->expert.eea_pref_list.c_str());
+      return false;
+    }
+  }
+
+  // Parse EIA preference list
+  std::vector<std::string> eia_pref_list;
+  boost::split(eia_pref_list, args->expert.eia_pref_list,
+               boost::is_any_of(","));
+  i = 0;
+  for (std::vector<std::string>::iterator it = eia_pref_list.begin();
+       it != eia_pref_list.end() && i < srslte::INTEGRITY_ALGORITHM_ID_N_ITEMS;
+       it++) {
+    boost::trim_left(*it);
+    if ((*it).compare("EIA0") == 0) {
+      rrc_cfg.eia_preference_list[i] = srslte::INTEGRITY_ALGORITHM_ID_EIA0;
+      i++;
+    } else if ((*it).compare("EIA1") == 0) {
+      rrc_cfg.eia_preference_list[i] = srslte::INTEGRITY_ALGORITHM_ID_128_EIA1;
+      i++;
+    } else if ((*it).compare("EIA2") == 0) {
+      rrc_cfg.eia_preference_list[i] = srslte::INTEGRITY_ALGORITHM_ID_128_EIA2;
+      i++;
+    } else {
+      fprintf(stderr, "Failed to parse EIA prefence list %s \n",
+              args->expert.eia_pref_list.c_str());
+      return false;
+    }
+  }
+
   // Copy cell struct to rrc and phy
   memcpy(&rrc_cfg.cell, &cell_cfg, sizeof(srslte_cell_t));
   memcpy(&phy_cfg.cell, &cell_cfg, sizeof(srslte_cell_t));

--- a/srsenb/src/main.cc
+++ b/srsenb/src/main.cc
@@ -155,6 +155,8 @@ void parse_args(all_args_t *args, int argc, char* argv[]) {
     ("expert.print_buffer_state", bpo::value<bool>(&args->expert.print_buffer_state)->default_value(false), "Prints on the console the buffer state every 10 seconds")
     ("expert.m1u_multiaddr", bpo::value<string>(&args->expert.m1u_multiaddr)->default_value("239.255.0.1"), "M1-U Multicast address the eNB joins.")
     ("expert.m1u_if_addr", bpo::value<string>(&args->expert.m1u_if_addr)->default_value("127.0.1.201"), "IP address of the interface the eNB will listen for M1-U traffic.")
+    ("expert.eea_pref_list", bpo::value<string>(&args->expert.eea_pref_list)->default_value("EEA0, EEA2, EEA1"), "Ordered preference list for the selection of encryption algorithm (EEA) (default: EEA0, EEA2, EEA1).")
+    ("expert.eia_pref_list", bpo::value<string>(&args->expert.eia_pref_list)->default_value("EIA2, EIA1, EIA0"), "Ordered preference list for the selection of integrity algorithm (EIA) (default: EIA2, EIA1, EIA0).")
   ;
 
   // Positional options - config file location

--- a/srsenb/src/upper/pdcp.cc
+++ b/srsenb/src/upper/pdcp.cc
@@ -117,9 +117,21 @@ void pdcp::config_security(uint16_t rnti, uint32_t lcid, uint8_t* k_rrc_enc_, ui
   pthread_rwlock_rdlock(&rwlock);
   if (users.count(rnti)) {
     users[rnti].pdcp->config_security(lcid, k_rrc_enc_, k_rrc_int_, k_up_enc_, cipher_algo_, integ_algo_);
-    users[rnti].pdcp->enable_integrity(lcid);
-    users[rnti].pdcp->enable_encryption(lcid);
   }
+  pthread_rwlock_unlock(&rwlock);
+}
+
+void pdcp::enable_integrity(uint16_t rnti, uint32_t lcid)
+{
+  pthread_rwlock_rdlock(&rwlock);
+  users[rnti].pdcp->enable_integrity(lcid);
+  pthread_rwlock_unlock(&rwlock);
+}
+
+void pdcp::enable_encryption(uint16_t rnti, uint32_t lcid)
+{
+  pthread_rwlock_rdlock(&rwlock);
+  users[rnti].pdcp->enable_encryption(lcid);
   pthread_rwlock_unlock(&rwlock);
 }
 

--- a/srsenb/src/upper/pdcp.cc
+++ b/srsenb/src/upper/pdcp.cc
@@ -110,13 +110,13 @@ void pdcp::reset(uint16_t rnti)
   pthread_rwlock_unlock(&rwlock);
 }
 
-void pdcp::config_security(uint16_t rnti, uint32_t lcid, uint8_t* k_rrc_enc_, uint8_t* k_rrc_int_, 
-                           srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_, 
+void pdcp::config_security(uint16_t rnti, uint32_t lcid, uint8_t* k_rrc_enc_, uint8_t* k_rrc_int_, uint8_t* k_up_enc_,
+                           srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo_,
                            srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo_)
 {
   pthread_rwlock_rdlock(&rwlock);
   if (users.count(rnti)) {
-    users[rnti].pdcp->config_security(lcid, k_rrc_enc_, k_rrc_int_, cipher_algo_, integ_algo_);
+    users[rnti].pdcp->config_security(lcid, k_rrc_enc_, k_rrc_int_, k_up_enc_, cipher_algo_, integ_algo_);
     users[rnti].pdcp->enable_integrity(lcid);
     users[rnti].pdcp->enable_encryption(lcid);
   }

--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -1914,24 +1914,16 @@ bool rrc::ue::select_security_algorithms() {
 
   bool enc_algo_found = false;
   bool integ_algo_found = false;
-  bool zero_vector = true;
   int i = 0;
-  int j = 0;
   for (i = 0; i < srslte::CIPHERING_ALGORITHM_ID_N_ITEMS; i++) {
     switch (parent->cfg.eea_preference_list[i]) {
     case srslte::CIPHERING_ALGORITHM_ID_EEA0:
       // “all bits equal to 0” – UE supports no other algorithm than EEA0,
-      zero_vector = true;
-      for (j = 0; j < LIBLTE_S1AP_ENCRYPTIONALGORITHMS_BIT_STRING_LEN; j++) {
-        if (security_capabilities.encryptionAlgorithms.buffer[j]) {
-          zero_vector = false;
-        }
-      }
-      if (zero_vector == true) {
-        cipher_algo = srslte::CIPHERING_ALGORITHM_ID_EEA0;
-        enc_algo_found = true;
-        break;
-      }
+      // specification does not cover the case in which EEA0 is supported with other algorithms
+      // just assume that EEA0 is always supported even this can not be explicity signaled by S1AP
+      cipher_algo    = srslte::CIPHERING_ALGORITHM_ID_EEA0;
+      enc_algo_found = true;
+      parent->rrc_log->info("Selected EEA0 as RRC encryption algorithm\n");
       break;
     case srslte::CIPHERING_ALGORITHM_ID_128_EEA1:
       // “first bit” – 128-EEA1,
@@ -1939,7 +1931,10 @@ bool rrc::ue::select_security_algorithms() {
               .buffer[srslte::CIPHERING_ALGORITHM_ID_128_EEA1 - 1]) {
         cipher_algo = srslte::CIPHERING_ALGORITHM_ID_128_EEA1;
         enc_algo_found = true;
+        parent->rrc_log->info("Selected EEA1 as RRC encryption algorithm\n");
         break;
+      } else {
+        parent->rrc_log->info("Failed to selected EEA1 as RRC encryption algorithm, due to unsupported algorithm\n");
       }
       break;
     case srslte::CIPHERING_ALGORITHM_ID_128_EEA2:
@@ -1948,7 +1943,10 @@ bool rrc::ue::select_security_algorithms() {
               .buffer[srslte::CIPHERING_ALGORITHM_ID_128_EEA2 - 1]) {
         cipher_algo = srslte::CIPHERING_ALGORITHM_ID_128_EEA2;
         enc_algo_found = true;
+        parent->rrc_log->info("Selected EEA2 as RRC encryption algorithm\n");
         break;
+      } else {
+        parent->rrc_log->info("Failed to selected EEA2 as RRC encryption algorithm, due to unsupported algorithm\n");
       }
       break;
     default:
@@ -1963,33 +1961,34 @@ bool rrc::ue::select_security_algorithms() {
   for (i = 0; i < srslte::INTEGRITY_ALGORITHM_ID_N_ITEMS; i++) {
     switch (parent->cfg.eia_preference_list[i]) {
     case srslte::INTEGRITY_ALGORITHM_ID_EIA0:
-      // “all bits equal to 0” – UE supports no other algorithm than EEA0,
-      zero_vector = true;
-      for (j = 0; j < LIBLTE_S1AP_INTEGRITYPROTECTIONALGORITHMS_BIT_STRING_LEN;
-           j++) {
-        if (security_capabilities.integrityProtectionAlgorithms.buffer[j]) {
-          zero_vector = false;
-        }
-      }
-      if (zero_vector == true) {
-        integ_algo = srslte::INTEGRITY_ALGORITHM_ID_EIA0;
-        integ_algo_found = true;
-      }
+      // “all bits equal to 0” – UE supports no other algorithm than EIA0,
+      // specification does not cover the case in which EIA0 is supported with other algorithms
+      // just assume that EIA0 is always supported even this can not be explicity signaled by S1AP
+      // EIA0 should only be accepted in emergency attach requests
+      integ_algo       = srslte::INTEGRITY_ALGORITHM_ID_EIA0;
+      integ_algo_found = true;
+      parent->rrc_log->info("Selected EIA0 as RRC integrity algorithm. Emergency attach request?!\n");
       break;
     case srslte::INTEGRITY_ALGORITHM_ID_128_EIA1:
-      // “first bit” – 128-EEA1,
-      if (security_capabilities.encryptionAlgorithms
+      // “first bit” – 128-EIA1,
+      if (security_capabilities.integrityProtectionAlgorithms
               .buffer[srslte::INTEGRITY_ALGORITHM_ID_128_EIA1 - 1]) {
         integ_algo = srslte::INTEGRITY_ALGORITHM_ID_128_EIA1;
         integ_algo_found = true;
+        parent->rrc_log->info("Selected EIA1 as RRC integrity algorithm.\n");
+      } else {
+        parent->rrc_log->info("Failed to selected EIA1 as RRC encryption algorithm, due to unsupported algorithm\n");
       }
       break;
     case srslte::INTEGRITY_ALGORITHM_ID_128_EIA2:
-      // “second bit” – 128-EEA2,
-      if (security_capabilities.encryptionAlgorithms
+      // “second bit” – 128-EIA2,
+      if (security_capabilities.integrityProtectionAlgorithms
               .buffer[srslte::INTEGRITY_ALGORITHM_ID_128_EIA2 - 1]) {
         integ_algo = srslte::INTEGRITY_ALGORITHM_ID_128_EIA2;
         integ_algo_found = true;
+        parent->rrc_log->info("Selected EIA2 as RRC integrity algorithm.\n");
+      } else{
+        parent->rrc_log->info("Failed to selected EIA2 as RRC encryption algorithm, due to unsupported algorithm\n");
       }
       break;
     default:
@@ -2005,6 +2004,7 @@ bool rrc::ue::select_security_algorithms() {
   if (integ_algo_found == false || enc_algo_found == false) {
     // TODO: if no security algorithm found abort radio connection and issue
     // cryption-and-or-integrity-protection-algorithms-not-supported message
+    parent->rrc_log->error("Did not find a matching integrity or encryption algorithm with the UE\n"); 
     return false;
   }
   return true;

--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -1916,12 +1916,13 @@ bool rrc::ue::select_security_algorithms() {
   bool integ_algo_found = false;
   bool zero_vector = true;
   int i = 0;
+  int j = 0;
   for (i = 0; i < srslte::CIPHERING_ALGORITHM_ID_N_ITEMS; i++) {
     switch (parent->cfg.eea_preference_list[i]) {
     case srslte::CIPHERING_ALGORITHM_ID_EEA0:
       // “all bits equal to 0” – UE supports no other algorithm than EEA0,
       zero_vector = true;
-      for (int j; j < LIBLTE_S1AP_ENCRYPTIONALGORITHMS_BIT_STRING_LEN; j++) {
+      for (j = 0; j < LIBLTE_S1AP_ENCRYPTIONALGORITHMS_BIT_STRING_LEN; j++) {
         if (security_capabilities.encryptionAlgorithms.buffer[j]) {
           zero_vector = false;
         }
@@ -1964,7 +1965,7 @@ bool rrc::ue::select_security_algorithms() {
     case srslte::INTEGRITY_ALGORITHM_ID_EIA0:
       // “all bits equal to 0” – UE supports no other algorithm than EEA0,
       zero_vector = true;
-      for (int j; j < LIBLTE_S1AP_INTEGRITYPROTECTIONALGORITHMS_BIT_STRING_LEN;
+      for (j = 0; j < LIBLTE_S1AP_INTEGRITYPROTECTIONALGORITHMS_BIT_STRING_LEN;
            j++) {
         if (security_capabilities.integrityProtectionAlgorithms.buffer[j]) {
           zero_vector = false;

--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -1212,7 +1212,7 @@ void rrc::ue::set_security_key(uint8_t* key, uint32_t length)
   memcpy(k_enb, key, length);
   parent->rrc_log->info_hex(k_enb, 32, "Key eNodeB (k_enb)");
   // Select algos (TODO: use security capabilities and config preferences)
-  cipher_algo = srslte::CIPHERING_ALGORITHM_ID_EEA0; // FIXME: Should i keep this type???
+  cipher_algo = srslte::CIPHERING_ALGORITHM_ID_128_EEA2; // FIXME: Should i keep this type???
   integ_algo  = srslte::INTEGRITY_ALGORITHM_ID_128_EIA1;
 
   // Generate K_rrc_enc and K_rrc_int
@@ -1234,7 +1234,7 @@ void rrc::ue::set_security_key(uint8_t* key, uint32_t length)
 
   parent->rrc_log->info_hex(k_rrc_enc, 32, "RRC Encryption Key (k_rrc_enc)");
   parent->rrc_log->info_hex(k_rrc_int, 32, "RRC Integrity Key (k_rrc_int)");
-  parent->rrc_log->info_hex(k_up_enc, 32, "RRC Encryption Key (k_rrc_enc)");
+  parent->rrc_log->info_hex(k_up_enc, 32, "UP Encryption Key (k_up_enc)");
 }
 
 bool rrc::ue::setup_erabs(LIBLTE_S1AP_E_RABTOBESETUPLISTCTXTSUREQ_STRUCT *e)
@@ -1771,6 +1771,7 @@ void rrc::ue::send_connection_reconf(srslte::byte_buffer_t *pdu)
   // Configure DRB1 in PDCP
   pdcp_cnfg.is_control = false;
   pdcp_cnfg.is_data = true;
+  pdcp_cnfg.bearer_id = 1; // TODO: Review all ID mapping LCID DRB ERAB EPSBID Mapping 
   if (conn_reconf->rr_cfg_ded.drb_to_add_mod_list[0].pdcp_cfg.rlc_um_present) {
     if (conn_reconf->rr_cfg_ded.drb_to_add_mod_list[0].pdcp_cfg.rlc_um.pdcp_sn_size.value ==
         pdcp_cfg_s::rlc_um_s_::pdcp_sn_size_e_::len7bits) {
@@ -1839,7 +1840,7 @@ void rrc::ue::send_connection_reconf_new_bearer(LIBLTE_S1AP_E_RABTOBESETUPLISTBE
     parent->rlc->add_bearer(rnti, lcid, &drb_item.rlc_cfg);
     // Configure DRB in PDCP
     srslte::srslte_pdcp_config_t pdcp_config;
-    pdcp_config.bearer_id = drb_item.drb_id;
+    pdcp_config.bearer_id = drb_item.drb_id - 1; // TODO: Review all ID mapping LCID DRB ERAB EPSBID Mapping
     pdcp_config.is_data = true;
     pdcp_config.direction = SECURITY_DIRECTION_DOWNLINK;
     parent->pdcp->add_bearer(rnti, lcid, pdcp_config);

--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -804,7 +804,7 @@ void rrc::configure_security(uint16_t rnti,
                              srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo)
 {
   // TODO: add k_up_enc, k_up_int support to PDCP
-  pdcp->config_security(rnti, lcid, k_rrc_enc, k_rrc_int, cipher_algo, integ_algo);
+  pdcp->config_security(rnti, lcid, k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
 }
 
 /*******************************************************************************

--- a/srsenb/src/upper/rrc.cc
+++ b/srsenb/src/upper/rrc.cc
@@ -1214,7 +1214,7 @@ void rrc::ue::set_security_key(uint8_t* key, uint32_t length)
   // Selects security algorithms (cipher_algo and integ_algo) based on capabilities and config preferences 
   select_security_algorithms();
 
-  parent->rrc_log->info("Selected security algorithms EEA: EEA-%d EIA: EIA-%d\n", cipher_algo, integ_algo);
+  parent->rrc_log->info("Selected security algorithms EEA: EEA%d EIA: EIA%d\n", cipher_algo, integ_algo);
   
   // Generate K_rrc_enc and K_rrc_int
   srslte::security_generate_k_rrc(k_enb, cipher_algo, integ_algo, k_rrc_enc, k_rrc_int);
@@ -1901,35 +1901,23 @@ void rrc::ue::send_ue_cap_enquiry()
 
 /********************** HELPERS ***************************/
 
-bool rrc::ue::select_security_algorithms()
-{
-  srslte::CIPHERING_ALGORITHM_ID_ENUM
-      enc_algo_preference[srslte::CIPHERING_ALGORITHM_ID_N_ITEMS] = {
-          srslte::CIPHERING_ALGORITHM_ID_128_EEA2,
-          srslte::CIPHERING_ALGORITHM_ID_128_EEA1,
-          srslte::CIPHERING_ALGORITHM_ID_EEA0};
-
-  srslte::INTEGRITY_ALGORITHM_ID_ENUM
-      intgrity_algo_preference[srslte::INTEGRITY_ALGORITHM_ID_N_ITEMS] = {
-          srslte::INTEGRITY_ALGORITHM_ID_128_EIA2,
-          srslte::INTEGRITY_ALGORITHM_ID_128_EIA1,
-          srslte::INTEGRITY_ALGORITHM_ID_EIA0};
-
+bool rrc::ue::select_security_algorithms() {
   // Each position in the bitmap represents an encryption algorithm:
   // “all bits equal to 0” – UE supports no other algorithm than EEA0,
   // “first bit” – 128-EEA1,
   // “second bit” – 128-EEA2,
   // “third bit” – 128-EEA3,
-  // other bits reserved for future use. Value ‘1’ indicates support and value ‘0’ indicates no support of the algorithm.
+  // other bits reserved for future use. Value ‘1’ indicates support and value
+  // ‘0’ indicates no support of the algorithm.
   // Algorithms are defined in TS 33.401 [15].
-  // Note: information missing 
+  // Note: information missing
 
-  bool enc_algo_found = false; 
+  bool enc_algo_found = false;
   bool integ_algo_found = false;
   bool zero_vector = true;
   int i = 0;
   for (i = 0; i < srslte::CIPHERING_ALGORITHM_ID_N_ITEMS; i++) {
-    switch (enc_algo_preference[i]) {
+    switch (parent->cfg.eea_preference_list[i]) {
     case srslte::CIPHERING_ALGORITHM_ID_EEA0:
       // “all bits equal to 0” – UE supports no other algorithm than EEA0,
       zero_vector = true;
@@ -1972,7 +1960,7 @@ bool rrc::ue::select_security_algorithms()
   }
 
   for (i = 0; i < srslte::INTEGRITY_ALGORITHM_ID_N_ITEMS; i++) {
-    switch (intgrity_algo_preference[i]) {
+    switch (parent->cfg.eia_preference_list[i]) {
     case srslte::INTEGRITY_ALGORITHM_ID_EIA0:
       // “all bits equal to 0” – UE supports no other algorithm than EEA0,
       zero_vector = true;
@@ -2013,7 +2001,7 @@ bool rrc::ue::select_security_algorithms()
     }
   }
 
-  if(integ_algo_found == false || enc_algo_found == false){
+  if (integ_algo_found == false || enc_algo_found == false) {
     // TODO: if no security algorithm found abort radio connection and issue
     // cryption-and-or-integrity-protection-algorithms-not-supported message
     return false;

--- a/srsepc/src/mme/mme_gtpc.cc
+++ b/srsepc/src/mme/mme_gtpc.cc
@@ -225,7 +225,7 @@ mme_gtpc::handle_create_session_response(srslte::gtpc_pdu *cs_resp_pdu)
 
   //Save UE IP to nas ctxt
   emm_ctx->ue_ip.s_addr = cs_resp->paa.ipv4;
-  m_mme_gtpc_log->console("SPGW Allocated IP %s to ISMI %015lu\n",inet_ntoa(emm_ctx->ue_ip),emm_ctx->imsi);
+  m_mme_gtpc_log->console("SPGW Allocated IP %s to IMSI %015lu\n",inet_ntoa(emm_ctx->ue_ip),emm_ctx->imsi);
   //Save SGW ctrl F-TEID in GTP-C context
   std::map<uint64_t,struct gtpc_ctx>::iterator it_g = m_imsi_to_gtpc_ctx.find(imsi);
   if(it_g == m_imsi_to_gtpc_ctx.end()) {

--- a/srsue/src/upper/rrc.cc
+++ b/srsue/src/upper/rrc.cc
@@ -1569,7 +1569,7 @@ bool rrc::ho_prepare() {
     usim->generate_as_keys_ho(mob_ctrl_info->target_pci, phy->get_current_earfcn(), ncc, k_rrc_enc, k_rrc_int, k_up_enc,
                               k_up_int, cipher_algo, integ_algo);
 
-    pdcp->config_security_all(k_rrc_enc, k_rrc_int, cipher_algo, integ_algo);
+    pdcp->config_security_all(k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
     send_rrc_con_reconfig_complete();
   }
   return true;
@@ -2151,7 +2151,7 @@ void rrc::parse_dl_dcch(uint32_t lcid, byte_buffer_t* pdu)
       security_is_activated = true;
 
       // Configure PDCP for security
-      pdcp->config_security(lcid, k_rrc_enc, k_rrc_int, cipher_algo, integ_algo);
+      pdcp->config_security(lcid, k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
       pdcp->enable_integrity(lcid);
       send_security_mode_complete();
       pdcp->enable_encryption(lcid);
@@ -2668,7 +2668,7 @@ void rrc::add_srb(srb_to_add_mod_s* srb_cnfg)
   pdcp_cfg.bearer_id = srb_cnfg->srb_id;
   pdcp->add_bearer(srb_cnfg->srb_id, pdcp_cfg);
   if(RB_ID_SRB2 == srb_cnfg->srb_id) {
-    pdcp->config_security(srb_cnfg->srb_id, k_rrc_enc, k_rrc_int, cipher_algo, integ_algo);
+    pdcp->config_security(srb_cnfg->srb_id, k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
     pdcp->enable_integrity(srb_cnfg->srb_id);
     pdcp->enable_encryption(srb_cnfg->srb_id);
   }
@@ -2737,7 +2737,7 @@ void rrc::add_drb(drb_to_add_mod_s* drb_cnfg)
     }
   }
   pdcp->add_bearer(lcid, pdcp_cfg);
-  pdcp->config_security(lcid, k_up_enc, k_up_int, cipher_algo, integ_algo);
+  pdcp->config_security(lcid, k_rrc_enc, k_rrc_int, k_up_enc, cipher_algo, integ_algo);
   pdcp->enable_encryption(lcid);
 
   // Setup RLC

--- a/srsue/src/upper/usim.cc
+++ b/srsue/src/upper/usim.cc
@@ -80,7 +80,7 @@ int usim::init(usim_args_t *args, srslte::log *usim_log_)
       imsi += imsi_c[i] - '0';
     }
   } else {
-    usim_log->error("Invalid length for ISMI: %zu should be %d\n", args->imsi.length(), 15);
+    usim_log->error("Invalid length for IMSI: %zu should be %d\n", args->imsi.length(), 15);
     usim_log->console("Invalid length for IMSI: %zu should be %d\n", args->imsi.length(), 15);
   }
 


### PR DESCRIPTION
Hi, 

I have added control and user plane traffic encryption to the eNodeB based on preferences set in the enb.conf file. For this, I have added / changed the pdcp to rrc interface. Further, I have added a function for preference selection in rrc::ue and we are able to parse the config file for an *ordered* preference list. I would like to add a similar preference selection for the MME encryption / integrity algorithm.

Best regards,
David  