### PR TITLE
Fix enb putting the SSS in the wrong place with ext CP enabled.

### DIFF
--- a/lib/src/phy/enb/enb_dl.c
+++ b/lib/src/phy/enb/enb_dl.c
@@ -333,7 +333,7 @@ void srslte_enb_dl_put_sync(srslte_enb_dl_t *q, uint32_t sf_idx)
     for (int p = 0; p < q->cell.nof_ports; p++) {
       srslte_pss_put_slot(q->pss_signal, q->sf_symbols[p], q->cell.nof_prb, q->cell.cp);
       srslte_sss_put_slot(sf_idx ? q->sss_signal5 : q->sss_signal0, q->sf_symbols[p],
-                          q->cell.nof_prb, SRSLTE_CP_NORM);
+                          q->cell.nof_prb, q->cell.cp);
     }
   }  
 }


### PR DESCRIPTION
I noticed that with the extended cyclic prefix enabled, the PSS was missing. It turned out that the SSS had been put on top of the PSS because it was using the wrong cyclic prefix mode.

There is still something wrong with extended prefix mode as phy_dl_test can't pass traffic, but this is a small step towards that working.