### PR TITLE
C/C++ linkage issue with complex.h CentOS 7

### DIFF
--- a/lib/include/srslte/phy/modem/demod_hard.h
+++ b/lib/include/srslte/phy/modem/demod_hard.h
@@ -31,7 +31,6 @@
 #ifndef SRSLTE_DEMOD_HARD_H
 #define SRSLTE_DEMOD_HARD_H
 
-//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/config.h"

--- a/lib/include/srslte/phy/modem/demod_hard.h
+++ b/lib/include/srslte/phy/modem/demod_hard.h
@@ -31,7 +31,7 @@
 #ifndef SRSLTE_DEMOD_HARD_H
 #define SRSLTE_DEMOD_HARD_H
 
-#include <complex.h>
+//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/config.h"

--- a/lib/include/srslte/phy/modem/demod_soft.h
+++ b/lib/include/srslte/phy/modem/demod_soft.h
@@ -31,7 +31,7 @@
 #ifndef SRSLTE_DEMOD_SOFT_H
 #define SRSLTE_DEMOD_SOFT_H
 
-#include <complex.h>
+//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/config.h"

--- a/lib/include/srslte/phy/modem/demod_soft.h
+++ b/lib/include/srslte/phy/modem/demod_soft.h
@@ -31,7 +31,6 @@
 #ifndef SRSLTE_DEMOD_SOFT_H
 #define SRSLTE_DEMOD_SOFT_H
 
-//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/config.h"

--- a/lib/include/srslte/phy/modem/mod.h
+++ b/lib/include/srslte/phy/modem/mod.h
@@ -31,7 +31,7 @@
 #ifndef SRSLTE_MOD_H
 #define SRSLTE_MOD_H
 
-#include <complex.h>
+//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/config.h"

--- a/lib/include/srslte/phy/modem/mod.h
+++ b/lib/include/srslte/phy/modem/mod.h
@@ -31,7 +31,6 @@
 #ifndef SRSLTE_MOD_H
 #define SRSLTE_MOD_H
 
-//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/config.h"

--- a/lib/include/srslte/phy/modem/modem_table.h
+++ b/lib/include/srslte/phy/modem/modem_table.h
@@ -32,7 +32,7 @@
 #define SRSLTE_MODEM_TABLE_H
 
 #include <stdbool.h>
-#include <complex.h>
+//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/phy/common/phy_common.h"

--- a/lib/include/srslte/phy/modem/modem_table.h
+++ b/lib/include/srslte/phy/modem/modem_table.h
@@ -32,7 +32,6 @@
 #define SRSLTE_MODEM_TABLE_H
 
 #include <stdbool.h>
-//#include <complex.h>
 #include <stdint.h>
 
 #include "srslte/phy/common/phy_common.h"

--- a/lib/src/phy/modem/demod_soft.c
+++ b/lib/src/phy/modem/demod_soft.c
@@ -21,6 +21,7 @@
 
 #include <stdlib.h>
 #include <strings.h>
+#include <complex.h>
 
 #include "srslte/phy/modem/demod_soft.h"
 #include "srslte/phy/utils/bit.h"

--- a/lib/src/phy/phch/phich.c
+++ b/lib/src/phy/phch/phich.c
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <math.h>
+#include <complex.h>
 
 #include "srslte/phy/phch/regs.h"
 #include "srslte/phy/phch/phich.h"


### PR DESCRIPTION
Noted a error In CentOS 7 when a C++ application included phich.h with C linkage.

Offending code
```
extern "C" {
#include "srslte/phy/phch/ra.h"
#include "srslte/phy/phch/dci.h"
#include "srslte/phy/phch/phich.h"
}
```
Error:
```
In file included from /usr/include/c++/4.8.2/complex:42:0,
                 from /usr/include/c++/4.8.2/ccomplex:38,
                 from /usr/include/c++/4.8.2/complex.h:32,
                 from /home/jgiovatto/Devel/srsLTE-emane/lib/include/srslte/phy/modem/modem_table.h:35,
                 from /home/jgiovatto/Devel/srsLTE-emane/lib/include/srslte/phy/modem/demod_soft.h:38,
                 from /home/jgiovatto/Devel/srsLTE-emane/lib/include/srslte/phy/phch/phich.h:39,
/usr/include/c++/4.8.2/bits/cpp_type_traits.h:72:3: error: template with C linkage
   template<typename _Iterator, typename _Container>
```
Possibly fix is a simple as moving the offending file `complex.h` out of the header files where it does not seem to be needed and into the c-library impl files as needed.

This was only noted in CentOS 7, and NOT later Fedora or Ubuntu distros.