### PR TITLE
chap auth random seed

### DIFF
--- a/srsue/src/upper/nas.cc
+++ b/srsue/src/upper/nas.cc
@@ -116,9 +116,6 @@ void nas::init(
     have_ctxt = true;
   }
 
-  // set seed for rand (used in CHAP auth)
-  srand(time(NULL));
-
   running = true;
 }
 

--- a/srsue/src/upper/rrc.cc
+++ b/srsue/src/upper/rrc.cc
@@ -177,8 +177,13 @@ void rrc::init(phy_interface_rrc*    phy_,
   set_mac_default();
 
   measurements.init(this);
-  // set seed for rand (used in attach)
-  srand(time(NULL));
+
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  rrc_log->info("using srand seed of %ld\n", tv.tv_usec);
+
+  // set seed (used in CHAP auth and attach)
+  srand(tv.tv_usec);
 
   running = true;
   start();


### PR DESCRIPTION
Use time in microseconds vs time in seconds to generate a more unique random pattern per ue.
When multiple ue are able to attach simultaneously such as in a emulated environment time in seconds may not be unique per ue.

Removed extra call to srand in srsue process 1 per process should be sufficient.