### PR TITLE
Fix bug wherein blank lines or trailing newlines causes parsing of user_db.csv to fail

### DIFF
--- a/srsepc/src/hss/hss.cc
+++ b/srsepc/src/hss/hss.cc
@@ -110,7 +110,7 @@ bool hss::read_db_file(std::string db_filename)
 
   std::string line;
   while (std::getline(m_db_file, line)) {
-    if (line[0] != '#') {
+    if (line[0] != '#' && line.length() > 0) {
       uint                     column_size = 10;
       std::vector<std::string> split       = split_string(line, ',');
       if (split.size() != column_size) {


### PR DESCRIPTION
This is an easy bugfix to improve handling of csv files with blank lines.  
