### PR TITLE
SRSENB: Add SIB7 (GERAN neighbor) support

### DIFF
--- a/srsenb/hdr/enb.h
+++ b/srsenb/hdr/enb.h
@@ -174,6 +174,7 @@ private:
   int  parse_sib2(std::string filename, asn1::rrc::sib_type2_s* data);
   int  parse_sib3(std::string filename, asn1::rrc::sib_type3_s* data);
   int  parse_sib4(std::string filename, asn1::rrc::sib_type4_s* data);
+  int  parse_sib7(std::string filename, asn1::rrc::sib_type7_s* data);
   int  parse_sib9(std::string filename, asn1::rrc::sib_type9_s* data);
   int  parse_sib13(std::string filename, asn1::rrc::sib_type13_r9_s* data);
   int  parse_sibs(all_args_t* args, rrc_cfg_t* rrc_cfg, phy_cfg_t* phy_config_common);

--- a/srsenb/src/enb_cfg_parser.h
+++ b/srsenb/src/enb_cfg_parser.h
@@ -79,6 +79,20 @@ private:
   asn1::rrc::sib_type4_s* data;
 };
 
+class field_carrier_freqs_info_list : public parser::field_itf
+{
+public:
+  field_carrier_freqs_info_list(asn1::rrc::sib_type7_s* data_) { data = data_; }
+  ~field_carrier_freqs_info_list(){}
+  int parse(Setting &root);
+  const char* get_name() {
+    return "carrier_freqs_info_list";
+  }
+
+private:
+  asn1::rrc::sib_type7_s* data;
+};
+
 class field_sf_mapping : public parser::field_itf
 {
 public:


### PR DESCRIPTION
This adds the required missing bits to the eNB config file parser
to enable minimalistic support of parsing SIB7 configuration.

SIB7 contains GERAN (GSM) neighbor cell information, which is important
if you are operating a combined 2G+4G netowrk and want to assist the UEs
to reselect GSM cells once they move out of LTE coverage.

An example SIB7 section looks as follows:

sib7 = {
    t_resel_geran = 1;
    carrier_freqs_info_list =
    (
        {
            cell_resel_prio = 0;
            ncc_permitted = 255;
            q_rx_lev_min = 0;
            thresh_x_high = 7;
            thresh_x_low = 7;

            start_arfcn = 871;
            band_ind = "dcs1800";
            explicit_list_of_arfcns = ( 873, 875, 877 );
        }

    );
};

Closes: #357