### PR TITLE
Fixed incorrect DCI location assignment in pdsch_enodeb.c example

### DIFF
--- a/lib/examples/pdsch_enodeb.c
+++ b/lib/examples/pdsch_enodeb.c
@@ -917,8 +917,8 @@ int main(int argc, char **argv) {
           /* Encode PDCCH */
           INFO("Putting DCI to location: n=%d, L=%d\n", locations[sf_idx][0].ncce, locations[sf_idx][0].L);
 
-          dci_msg.location = locations[sf_idx][0];
           srslte_dci_msg_pack_pdsch(&cell, &dl_sf, NULL, &dci_dl, &dci_msg);
+          dci_msg.location = locations[sf_idx][0];
           if (srslte_pdcch_encode(&pdcch, &dl_sf, &dci_msg, sf_symbols)) {
             ERROR("Error encoding DCI message\n");
             exit(-1);


### PR DESCRIPTION
Hi all,

the current version of pdsch_enodeb.c example always puts DCI at location ncce=0, L=0, which is incorrect.

Typical UE (and maybe automated tests) won't notice this issue if the signal is clear. DCI will be found anyway if they are decoded at location ncce=0 with L=8 or L=4 (in common search space), since the "empty" CCEs won't negatively influence the bit collection process prior to viterbi decoding.

Swapping two lines of code does fix this issue (cf. pdcch_test.c : 295, setting dci location *after* srslte_dci_msg_pack_pdsch(...)).

Regards
Robert