### PR TITLE
Fix ndi in dci_format1As_pack function

### DIFF
--- a/lib/examples/pdsch_enodeb.c
+++ b/lib/examples/pdsch_enodeb.c
@@ -917,8 +917,8 @@ int main(int argc, char **argv) {
           /* Encode PDCCH */
           INFO("Putting DCI to location: n=%d, L=%d\n", locations[sf_idx][0].ncce, locations[sf_idx][0].L);
 
-          dci_msg.location = locations[sf_idx][0];
           srslte_dci_msg_pack_pdsch(&cell, &dl_sf, NULL, &dci_dl, &dci_msg);
+          dci_msg.location = locations[sf_idx][0];
           if (srslte_pdcch_encode(&pdcch, &dl_sf, &dci_msg, sf_symbols)) {
             ERROR("Error encoding DCI message\n");
             exit(-1);

--- a/lib/src/phy/phch/dci.c
+++ b/lib/src/phy/phch/dci.c
@@ -672,7 +672,7 @@ static int dci_format1As_pack(
 
   srslte_bit_unpack(dci->pid, &y, HARQ_PID_LEN);
 
-  if (SRSLTE_RNTI_ISUSER(dci->rnti)) {
+  if (!SRSLTE_RNTI_ISUSER(dci->rnti)) {
     if (nof_prb >= 50 && dci->type2_alloc.mode == SRSLTE_RA_TYPE2_DIST) {
       *y++ = dci->type2_alloc.n_gap;
     } else {


### PR DESCRIPTION
Hi all,

the function ``dci_format_1As_pack(...)`` packs the new data indicator (ndi) incorrectly due to an inverted condition in line ``dci.c:675``: ``if (SRSLTE_RNTI_ISUSER(dci->rnti))``should be ``if (!SRSLTE_RNTI_ISUSER(dci->rnti))``.

For confidence, compare the inverse function ``dci_format_1As_unpack`` in line ``dci.c:785``.

Regards
Robert