### PR TITLE
Fixed inverted handling of fseek result value in srslte_filesource_seek

### DIFF
--- a/lib/src/phy/io/filesource.c
+++ b/lib/src/phy/io/filesource.c
@@ -45,7 +45,7 @@ void srslte_filesource_free(srslte_filesource_t *q) {
 }
 
 void srslte_filesource_seek(srslte_filesource_t *q, int pos) {
-  if (!fseek(q->f, pos, SEEK_SET)){
+  if (fseek(q->f, pos, SEEK_SET) != 0){
     perror("srslte_filesource_seek");
   }
 }


### PR DESCRIPTION
Hi all,

I have noticed an inverted handling of ``fseek``'s return value in function ``srslte_filesource_seek(...)``.

A sprious error message is printed, if the filesource is being seeked. Conversely, in case of a seek failure, no message is shown.

The behaviour is fixed in the attached pull request.

Kind Regards
Robert

References: http://man7.org/linux/man-pages/man3/fseek.3.html