### PR TITLE
Building srsLTE in a subdir of project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
 # Generate CMake to include build information
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/modules/SRSLTEbuildinfo.cmake.in
+  ${PROJECT_SOURCE_DIR}/cmake/modules/SRSLTEbuildinfo.cmake.in
   ${CMAKE_BINARY_DIR}/SRSLTEbuildinfo.cmake
 )
 
@@ -194,28 +194,33 @@ else(BLADERF_FOUND OR UHD_FOUND OR SOAPYSDR_FOUND OR ZEROMQ_FOUND)
 endif(BLADERF_FOUND OR UHD_FOUND OR SOAPYSDR_FOUND OR ZEROMQ_FOUND)
 
 # Boost
-if(ENABLE_SRSUE OR ENABLE_SRSENB OR ENABLE_SRSEPC)
-  if(BUILD_STATIC)
-    set(Boost_USE_STATIC_LIBS ON)
-  endif(BUILD_STATIC)
+if(BUILD_STATIC)
+  set(Boost_USE_STATIC_LIBS ON)
+endif(BUILD_STATIC)
 
-  set(BOOST_REQUIRED_COMPONENTS
-      program_options
-  )
-  if(UNIX AND EXISTS "/usr/lib64")
-      list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix
-  endif(UNIX AND EXISTS "/usr/lib64")
-  set(Boost_ADDITIONAL_VERSIONS
-      "1.35.0" "1.35" "1.36.0" "1.36" "1.37.0" "1.37" "1.38.0" "1.38" "1.39.0" "1.39"
-      "1.40.0" "1.40" "1.41.0" "1.41" "1.42.0" "1.42" "1.43.0" "1.43" "1.44.0" "1.44"
-      "1.45.0" "1.45" "1.46.0" "1.46" "1.47.0" "1.47" "1.48.0" "1.48" "1.49.0" "1.49"
-      "1.50.0" "1.50" "1.51.0" "1.51" "1.52.0" "1.52" "1.53.0" "1.53" "1.54.0" "1.54"
-      "1.55.0" "1.55" "1.56.0" "1.56" "1.57.0" "1.57" "1.58.0" "1.58" "1.59.0" "1.59"
-      "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
-      "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
-  )
-  find_package(Boost "1.35" COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
-endif(ENABLE_SRSUE OR ENABLE_SRSENB OR ENABLE_SRSEPC)
+set(BOOST_REQUIRED_COMPONENTS
+  program_options
+)
+if(UNIX AND EXISTS "/usr/lib64")
+  list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix
+endif(UNIX AND EXISTS "/usr/lib64")
+set(Boost_ADDITIONAL_VERSIONS
+    "1.35.0" "1.35" "1.36.0" "1.36" "1.37.0" "1.37" "1.38.0" "1.38" "1.39.0" "1.39"
+    "1.40.0" "1.40" "1.41.0" "1.41" "1.42.0" "1.42" "1.43.0" "1.43" "1.44.0" "1.44"
+    "1.45.0" "1.45" "1.46.0" "1.46" "1.47.0" "1.47" "1.48.0" "1.48" "1.49.0" "1.49"
+    "1.50.0" "1.50" "1.51.0" "1.51" "1.52.0" "1.52" "1.53.0" "1.53" "1.54.0" "1.54"
+    "1.55.0" "1.55" "1.56.0" "1.56" "1.57.0" "1.57" "1.58.0" "1.58" "1.59.0" "1.59"
+    "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
+    "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
+)
+find_package(Boost "1.35" COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+  link_directories(${Boost_LIBRARY_DIRS})
+else(Boost_FOUND)
+  message(FATAL_ERROR "Boost required to build srsLTE")
+endif (Boost_FOUND)
 
 # srsGUI
 if(ENABLE_GUI)
@@ -248,7 +253,7 @@ set(DATA_DIR share/${CPACK_PACKAGE_NAME})
 
 # Auto-generate config install helper and mark for installation
 configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/modules/SRSLTE_install_configs.sh.in
+        ${PROJECT_SOURCE_DIR}/cmake/modules/SRSLTE_install_configs.sh.in
         ${CMAKE_BINARY_DIR}/srslte_install_configs.sh
 )
 install(PROGRAMS ${CMAKE_BINARY_DIR}/srslte_install_configs.sh DESTINATION ${RUNTIME_DIR})

--- a/cmake/modules/SRSLTEbuildinfo.cmake.in
+++ b/cmake/modules/SRSLTEbuildinfo.cmake.in
@@ -2,20 +2,20 @@ cmake_minimum_required(VERSION 2.6)
 
 execute_process(
 COMMAND git rev-parse --abbrev-ref HEAD
-WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@"
+WORKING_DIRECTORY "@PROJECT_SOURCE_DIR@"
 OUTPUT_VARIABLE GIT_BRANCH
 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 execute_process(
 COMMAND git log -1 --format=%h
-WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@"
+WORKING_DIRECTORY "@PROJECT_SOURCE_DIR@"
 OUTPUT_VARIABLE GIT_COMMIT_HASH
 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 message(STATUS "Generating build_info.h")
 configure_file(
-  @CMAKE_SOURCE_DIR@/lib/include/srslte/build_info.h.in
+  @PROJECT_SOURCE_DIR@/lib/include/srslte/build_info.h.in
   @CMAKE_BINARY_DIR@/lib/include/srslte/build_info.h
 )


### PR DESCRIPTION
Hi,

those changes enable you to build srsLTE in a subdir / git submodule without any manual path adjustments. Further, I have enabled global boost requirements, as it is also required by some test cases and not only by the srsUE, srsEPC and SRSENB applications.

Best regards,
David