### PR TITLE
Minor fixes/improvements.

### DIFF
--- a/lib/src/asn1/liblte_m2ap.cc
+++ b/lib/src/asn1/liblte_m2ap.cc
@@ -768,7 +768,7 @@ LIBLTE_ERROR_ENUM liblte_m2ap_pack_ecgi(LIBLTE_M2AP_ECGI_STRUCT* ie, uint8_t** p
       return LIBLTE_ERROR_DECODE_FAIL;
     }
 
-    if (ie->iE_Extensions_present) {
+    if (ie->iE_Extensions) {
       if (liblte_m2ap_pack_protocolextensioncontainer(&ie->iE_Extensions, ptr) != LIBLTE_SUCCESS) {
         return LIBLTE_ERROR_DECODE_FAIL;
       }
@@ -2007,7 +2007,7 @@ LIBLTE_ERROR_ENUM liblte_m2ap_pack_mcchrelatedbcchconfigpermbsfnareaitem(
       return LIBLTE_ERROR_ENCODE_FAIL;
     }
 
-    if (ie->iE_Extensions_present) {
+    if (ie->iE_Extensions) {
       if (liblte_m2ap_unpack_protocolextensioncontainer(ptr, &ie->iE_Extensions) != LIBLTE_SUCCESS) {
         return LIBLTE_ERROR_DECODE_FAIL;
       }
@@ -2338,7 +2338,7 @@ LIBLTE_ERROR_ENUM liblte_m2ap_pack_mbsfnsubframeconfiguration(LIBLTE_M2AP_MBSFN_
       return LIBLTE_ERROR_ENCODE_FAIL;
     }
 
-    if (ie->iE_Extensions_present) {
+    if (ie->iE_Extensions) {
       if (liblte_m2ap_pack_protocolextensioncontainer(&ie->iE_Extensions, ptr) != LIBLTE_SUCCESS) {
         return LIBLTE_ERROR_DECODE_FAIL;
       }
@@ -2506,7 +2506,7 @@ LIBLTE_ERROR_ENUM liblte_m2ap_pack_pmchconfiguration(LIBLTE_M2AP_PMCH_CONFIGURAT
       return LIBLTE_ERROR_DECODE_FAIL;
     }
 
-    if (ie->iE_Extensions_present) {
+    if (ie->iE_Extensions) {
       if (liblte_m2ap_unpack_protocolextensioncontainer(ptr, &ie->iE_Extensions) != LIBLTE_SUCCESS) {
         return LIBLTE_ERROR_DECODE_FAIL;
       }
@@ -2590,7 +2590,7 @@ LIBLTE_ERROR_ENUM liblte_m2ap_pack_pmchconfigurationitem(LIBLTE_M2AP_PMCH_CONFIG
       return LIBLTE_ERROR_DECODE_FAIL;
     }
 
-    if (ie->iE_Extensions_present) {
+    if (ie->iE_Extensions) {
       if (liblte_m2ap_unpack_protocolextensioncontainer(ptr, &ie->iE_Extensions) != LIBLTE_SUCCESS) {
         return LIBLTE_ERROR_DECODE_FAIL;
       }
@@ -3597,6 +3597,10 @@ liblte_m2ap_pack_mbmsschedulinginformationresponse(LIBLTE_M2AP_MESSAGE_MBMSSCHED
 
       // ProtocolIE - Criticality Diagnostics
       tmp_ptr = tmp_msg.msg;
+      // liblte_m2ap_pack_criticalitydiagnostics function
+      // only returns:
+      //  - LIBLTE_ERROR_INVALID_INPUTS
+      //  - LIBLTE_ERROR_ENCODE_FAIL
       if (liblte_m2ap_pack_criticalitydiagnostics(&msg->CriticalityDiagnostics, &tmp_ptr) != LIBLTE_SUCCESS) {
         return LIBLTE_ERROR_ENCODE_FAIL;
       }
@@ -3650,6 +3654,10 @@ liblte_m2ap_unpack_mbmsschedulinginformationresponse(uint8_t**                  
       }
 
       if (LIBLTE_M2AP_IE_ID_CRITICALITYDIAGNOSTICS == ie_id) {
+        // liblte_m2ap_unpack_criticalitydiagnostics function
+        // only returns:
+        //  - LIBLTE_ERROR_INVALID_INPUTS
+        //  - LIBLTE_ERROR_DECODE_FAIL
         if (liblte_m2ap_unpack_criticalitydiagnostics(ptr, &msg->CriticalityDiagnostics) != LIBLTE_SUCCESS) {
           return LIBLTE_ERROR_DECODE_FAIL;
         }

--- a/lib/src/asn1/rrc_asn1_utils.cc
+++ b/lib/src/asn1/rrc_asn1_utils.cc
@@ -151,6 +151,7 @@ srslte::rlc_config_t make_rlc_config_t(const asn1::rrc::srb_to_add_mod_s& asn1_t
   } else {
     asn1::rrc::rrc_log_print(
         asn1::LOG_LEVEL_ERROR, "SRB %d does not support default initialization type\n", asn1_type.srb_id);
+    return rlc_config_t::srb_config(0);
   }
 }
 
@@ -431,7 +432,7 @@ void set_phy_cfg_t_dedicated_cfg(phy_cfg_t* cfg, const asn1::rrc::phys_cfg_ded_s
     }
   }
   if (asn1_type.sched_request_cfg_present) {
-    if (asn1_type.sched_request_cfg_present and asn1_type.sched_request_cfg.type() == asn1::rrc::setup_e::setup) {
+    if (asn1_type.sched_request_cfg.type() == asn1::rrc::setup_e::setup) {
       cfg->ul_cfg.pucch.I_sr          = asn1_type.sched_request_cfg.setup().sr_cfg_idx;
       cfg->ul_cfg.pucch.n_pucch_sr    = asn1_type.sched_request_cfg.setup().sr_pucch_res_idx;
       cfg->ul_cfg.pucch.sr_configured = true;
@@ -444,7 +445,7 @@ void set_phy_cfg_t_dedicated_cfg(phy_cfg_t* cfg, const asn1::rrc::phys_cfg_ded_s
 
   if (asn1_type.pdsch_cfg_ded_present) {
     // Configure PDSCH
-    if (asn1_type.pdsch_cfg_ded_present && cfg->dl_cfg.pdsch.p_b < 4) {
+    if (cfg->dl_cfg.pdsch.p_b < 4) {
       cfg->dl_cfg.pdsch.p_a         = asn1_type.pdsch_cfg_ded.p_a.to_number();
       cfg->dl_cfg.pdsch.power_scale = true;
     } else {

--- a/lib/src/common/pdu_queue.cc
+++ b/lib/src/common/pdu_queue.cc
@@ -48,6 +48,7 @@ uint8_t* pdu_queue::request(uint32_t len)
       log_h->error("Not enough buffers for MAC PDU\n");      
     }
     ERROR("Not enough buffers for MAC PDU\n");
+    exit(-1);
   }
   if ((void*) pdu->ptr != (void*) pdu) {
     ERROR("Fatal error in memory alignment in struct pdu_queue::pdu_t\n");

--- a/lib/src/common/threads.c
+++ b/lib/src/common/threads.c
@@ -132,7 +132,7 @@ bool threads_new_rt_cpu(pthread_t *thread, void *(*start_routine) (void*), void 
     }
   }
 
-  int err = pthread_create(thread, attr_enable ? &attr : NULL, start_routine, arg);
+  int err = pthread_create(thread, &attr, start_routine, arg);
   if (err) {
     if (EPERM == err) {
       perror("Warning: Failed to create thread with real-time priority. Creating it with normal priority");
@@ -148,9 +148,7 @@ bool threads_new_rt_cpu(pthread_t *thread, void *(*start_routine) (void*), void 
   } else {
     ret = true; 
   }
-  if (attr_enable) {
-    pthread_attr_destroy(&attr);
-  }
+  pthread_attr_destroy(&attr);
   return ret; 
 }
 

--- a/lib/src/phy/ch_estimation/chest_dl.c
+++ b/lib/src/phy/ch_estimation/chest_dl.c
@@ -194,6 +194,7 @@ void srslte_chest_dl_free(srslte_chest_dl_t *q)
 int srslte_chest_dl_res_init(srslte_chest_dl_res_t* q, uint32_t max_prb)
 {
   bzero(q, sizeof(srslte_chest_dl_res_t));
+  // SRSLTE_SF_LEN_RE(a, b) macro ends comapring b (SRSLTE_CP_NORM) against the same value
   q->nof_re = SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM);
   for (uint32_t i = 0; i < SRSLTE_MAX_PORTS; i++) {
     for (uint32_t j = 0; j < SRSLTE_MAX_PORTS; j++) {
@@ -202,6 +203,7 @@ int srslte_chest_dl_res_init(srslte_chest_dl_res_t* q, uint32_t max_prb)
         perror("malloc");
         return -1;
       }
+      // SRSLTE_SF_LEN_RE(a, b) macro ends comapring b (SRSLTE_CP_NORM) against the same value
       bzero(q->ce[i][j], SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM) * sizeof(cf_t));
     }
   }

--- a/lib/src/phy/ch_estimation/chest_ul.c
+++ b/lib/src/phy/ch_estimation/chest_ul.c
@@ -146,6 +146,7 @@ void srslte_chest_ul_free(srslte_chest_ul_t *q)
 int srslte_chest_ul_res_init(srslte_chest_ul_res_t* q, uint32_t max_prb)
 {
   bzero(q, sizeof(srslte_chest_ul_res_t));
+  // SRSLTE_SF_LEN_RE(a, b) macro ends comapring b (SRSLTE_CP_NORM) against the same value
   q->nof_re = SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM);
   q->ce     = srslte_vec_malloc(q->nof_re * sizeof(cf_t));
   if (!q->ce) {

--- a/lib/src/phy/ch_estimation/refsignal_dl.c
+++ b/lib/src/phy/ch_estimation/refsignal_dl.c
@@ -445,6 +445,7 @@ int srslte_refsignal_mbsfn_set_cell(srslte_refsignal_t * q, srslte_cell_t cell, 
   ret = SRSLTE_SUCCESS;
 
 free_and_exit:
+  // Expression is always false
   if (ret == SRSLTE_ERROR) {
     srslte_refsignal_free(q);
   }

--- a/lib/src/phy/ch_estimation/refsignal_ul.c
+++ b/lib/src/phy/ch_estimation/refsignal_ul.c
@@ -445,7 +445,7 @@ int srslte_refsignal_dmrs_pusch_pregen_put(srslte_refsignal_ul_t*             q,
 {
   uint32_t sf_idx = sf_cfg->tti % 10;
 
-  if (srslte_dft_precoding_valid_prb(pusch_cfg->grant.L_prb) && sf_idx < SRSLTE_NOF_SF_X_FRAME &&
+  if (srslte_dft_precoding_valid_prb(pusch_cfg->grant.L_prb) &&
       pusch_cfg->grant.n_dmrs < SRSLTE_NOF_CSHIFT) {
     srslte_refsignal_dmrs_pusch_put(
         q, pusch_cfg, pregen->r[pusch_cfg->grant.n_dmrs][sf_idx][pusch_cfg->grant.L_prb], sf_symbols);
@@ -850,14 +850,12 @@ int srslte_refsignal_srs_send_cs(uint32_t subframe_config, uint32_t sf_idx) {
       } else {
         return 1; 
       }
-    } else if (subframe_config == 14) {
+    } else {
       if (((sf_idx%tsfc)==7) || ((sf_idx%tsfc)==9)) {
         return 0; 
       } else {
         return 1; 
       }
-    } else {
-      return 0; 
     }
   } else {
     return SRSLTE_ERROR_INVALID_INPUTS;

--- a/lib/src/phy/ch_estimation/test/chest_test_ul.c
+++ b/lib/src/phy/ch_estimation/test/chest_test_ul.c
@@ -150,10 +150,10 @@ int main(int argc, char **argv) {
               bool group_hopping_en = false; 
               bool sequence_hopping_en = false; 
               
-              if (!t) {
+              if (!t) { // Never enter here, code block can be removed
                 group_hopping_en = false;
                 sequence_hopping_en = false;                
-              } else if (t == 1) {
+              } else if (t == 1) { // t can't be 1, maybe t == 2 and next t == 3?
                 group_hopping_en = false;
                 sequence_hopping_en = true;                
               } else if (t == 2) {

--- a/lib/src/phy/common/sequence.c
+++ b/lib/src/phy/common/sequence.c
@@ -53,8 +53,8 @@ int srslte_sequence_set_LTE_pr(srslte_sequence_t *q, uint32_t len, uint32_t seed
     return -1;
   }
 
-  if (len > q->max_len) {
-    ERROR("Error generating pseudo-random sequence: len %d is greater than allocated len %d\n", len, q->max_len);
+  if (len > q->cur_len) {
+    ERROR("Error generating pseudo-random sequence: len %d is greater than allocated len %d\n", len, q->cur_len);
     return -1;
   }
   pthread_mutex_lock(&mutex);

--- a/lib/src/phy/dft/dft_fftw.c
+++ b/lib/src/phy/dft/dft_fftw.c
@@ -146,6 +146,7 @@ int srslte_dft_plan_guru_c(srslte_dft_plan_t *plan, const int dft_points, srslte
 
   plan->p = fftwf_plan_guru_dft(1, &iodim, 1, &howmany_dims, in_buffer, out_buffer, sign, FFTW_TYPE);
   if (!plan->p) {
+    pthread_mutex_unlock(&fft_mutex);
     return -1;
   }
   pthread_mutex_unlock(&fft_mutex);

--- a/lib/src/phy/enb/enb_dl.c
+++ b/lib/src/phy/enb/enb_dl.c
@@ -45,6 +45,7 @@ int srslte_enb_dl_init(srslte_enb_dl_t *q, cf_t *out_buffer[SRSLTE_MAX_PORTS], u
     bzero(q, sizeof(srslte_enb_dl_t));
 
     for (int i=0;i<SRSLTE_MAX_PORTS;i++) {
+      // SRSLTE_SF_LEN_RE(a, b) macro ends comapring b (SRSLTE_CP_NORM) against the same value
       q->sf_symbols[i] = srslte_vec_malloc(SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM) * sizeof(cf_t));
       if (!q->sf_symbols[i]) {
         perror("malloc");

--- a/lib/src/phy/enb/enb_ul.c
+++ b/lib/src/phy/enb/enb_ul.c
@@ -43,12 +43,14 @@ int srslte_enb_ul_init(srslte_enb_ul_t *q,
 
     bzero(q, sizeof(srslte_enb_ul_t));
 
+    // SRSLTE_SF_LEN_RE(a, b) macro ends comapring b (SRSLTE_CP_NORM) against the same value
     q->sf_symbols = srslte_vec_malloc(SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM) * sizeof(cf_t));
     if (!q->sf_symbols) {
       perror("malloc");
       goto clean_exit;
     }
 
+    // SRSLTE_SF_LEN_RE(a, b) macro ends comapring b (SRSLTE_CP_NORM) against the same value
     q->chest_res.ce = srslte_vec_malloc(SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM) * sizeof(cf_t));
     if (!q->chest_res.ce) {
       perror("malloc");

--- a/lib/src/phy/fec/rm_turbo.c
+++ b/lib/src/phy/fec/rm_turbo.c
@@ -308,7 +308,6 @@ void srslte_rm_turbo_free_tables () {
     }
     rm_turbo_tables_generated = false;
   }
-  rm_turbo_tables_generated = false;
 }
 
 /**

--- a/lib/src/phy/io/netsink.c
+++ b/lib/src/phy/io/netsink.c
@@ -91,21 +91,19 @@ int srslte_netsink_write(srslte_netsink_t *q, void *buffer, int nof_bytes) {
     }
   } 
   int n = 0; 
-  if (q->connected) {
-    n = write(q->sockfd, buffer, nof_bytes);  
-    if (n < 0) {
-      if (errno == ECONNRESET) {
-        close(q->sockfd);
-        q->sockfd=socket(AF_INET, q->type==SRSLTE_NETSINK_TCP?SOCK_STREAM:SOCK_DGRAM,0);  
-        if (q->sockfd < 0) {
-          perror("socket");
-          return -1; 
-        }
-        q->connected = false; 
-        return 0; 
+  n = write(q->sockfd, buffer, nof_bytes);  
+  if (n < 0) {
+    if (errno == ECONNRESET) {
+      close(q->sockfd);
+      q->sockfd=socket(AF_INET, q->type==SRSLTE_NETSINK_TCP?SOCK_STREAM:SOCK_DGRAM,0);  
+      if (q->sockfd < 0) {
+        perror("socket");
+        return -1; 
       }
-    }    
-  } 
+      q->connected = false; 
+      return 0; 
+    }
+  }    
   return n;
 }
 

--- a/lib/src/phy/mimo/precoding.c
+++ b/lib/src/phy/mimo/precoding.c
@@ -303,14 +303,14 @@ int srslte_predecoding_single(cf_t *y_, cf_t *h_, cf_t *x, float *csi, int nof_s
   }
 
 #ifdef LV_HAVE_AVX
-  if (nof_symbols > 32 && nof_rxant <= 2) {
+  if (nof_symbols > 32) {
     return srslte_predecoding_single_avx(y, h, x, nof_rxant, nof_symbols, scaling, noise_estimate);
   } else {
     return srslte_predecoding_single_gen(y, h, x, nof_rxant, nof_symbols, scaling, noise_estimate);
   }
 #else
   #ifdef LV_HAVE_SSE
-    if (nof_symbols > 32 && nof_rxant <= 2) {
+    if (nof_symbols > 32) {
       return srslte_predecoding_single_sse(y, h, x, nof_rxant, nof_symbols, scaling, noise_estimate);
     } else {
       return srslte_predecoding_single_gen(y, h, x, nof_rxant, nof_symbols, scaling, noise_estimate);
@@ -1217,7 +1217,6 @@ static int srslte_predecoding_multiplex_2x2_zf_csi(cf_t *y[SRSLTE_MAX_PORTS],
     x[1][i] = (-h10 * y[0][i] + h00 * y[1][i]) * det;
 
     csi[i] = 1.0f;
-    csi[i] = 1.0f;
   }
   return SRSLTE_SUCCESS;
 }
@@ -1788,7 +1787,7 @@ int srslte_predecoding_type(cf_t*              y[SRSLTE_MAX_PORTS],
 
   switch (type) {
     case SRSLTE_TXSCHEME_CDD:
-      if (nof_layers >= 2 && nof_layers <= 4) {
+      if (nof_layers >= 2) {
         switch (mimo_decoder) {
           case SRSLTE_MIMO_DECODER_ZF:
             return srslte_predecoding_ccd_zf(y, h, x, csi, nof_rxant, nof_ports, nof_layers, nof_symbols, scaling);

--- a/lib/src/phy/mimo/test/pmi_select_test.c
+++ b/lib/src/phy/mimo/test/pmi_select_test.c
@@ -42,6 +42,7 @@ int main(int argc, char **argv) {
   float sinr_2l[SRSLTE_MAX_CODEBOOKS];
   float cn;
   uint32_t pmi[2];
+  // SRSLTE_SF_LEN_RE(6, SRSLTE_CP_NORM) second argument should be variable or the returned value is fixed  
   uint32_t nof_symbols = (uint32_t) SRSLTE_SF_LEN_RE(6, SRSLTE_CP_NORM);
   int ret = SRSLTE_ERROR;
 

--- a/lib/src/phy/phch/cqi.c
+++ b/lib/src/phy/phch/cqi.c
@@ -115,7 +115,7 @@ static int cqi_format2_subband_pack(srslte_cqi_cfg_t* cfg, srslte_cqi_format2_su
   uint8_t* body_ptr = buff;
   srslte_bit_unpack(msg->subband_cqi, &body_ptr, 4);
   srslte_bit_unpack(msg->subband_label, &body_ptr, cfg->subband_label_2_bits ? 2 : 1);
-  return 4 + (cfg->subband_label_2_bits) ? 2 : 1;
+  return 4 + ((cfg->subband_label_2_bits) ? 2 : 1);
 }
 
 int srslte_cqi_value_pack(srslte_cqi_cfg_t* cfg, srslte_cqi_value_t* value, uint8_t buff[SRSLTE_CQI_MAX_BITS])
@@ -212,7 +212,7 @@ static int cqi_format2_subband_unpack(srslte_cqi_cfg_t* cfg, uint8_t* buff, srsl
   uint8_t* body_ptr  = buff;
   msg->subband_cqi   = srslte_bit_pack(&body_ptr, 4);
   msg->subband_label = srslte_bit_pack(&body_ptr, cfg->subband_label_2_bits ? 2 : 1);
-  return 4 + (cfg->subband_label_2_bits) ? 2 : 1;
+  return 4 + ((cfg->subband_label_2_bits) ? 2 : 1);
 }
 
 int srslte_cqi_value_unpack(srslte_cqi_cfg_t* cfg, uint8_t buff[SRSLTE_CQI_MAX_BITS], srslte_cqi_value_t* value)
@@ -350,7 +350,7 @@ int srslte_cqi_size(srslte_cqi_cfg_t* cfg)
       }
       break;
     case SRSLTE_CQI_TYPE_SUBBAND:
-      size = 4 + (cfg->subband_label_2_bits) ? 2 : 1;
+      size = 4 + ((cfg->subband_label_2_bits) ? 2 : 1);
       break;
     case SRSLTE_CQI_TYPE_SUBBAND_UE:
       size = 4 + 2 + cfg->L;
@@ -519,7 +519,7 @@ static bool ri_send(uint32_t I_cqi_pmi, uint32_t I_ri, uint32_t tti, bool is_fdd
     return false;
   }
 
-  if (M_ri && N_p) {
+  if (N_p) {
     if ((tti - N_offset_p - N_offset_ri) % (N_p * M_ri) == 0) {
       return true;
     }

--- a/lib/src/phy/phch/pdsch.c
+++ b/lib/src/phy/phch/pdsch.c
@@ -1089,6 +1089,7 @@ int srslte_pdsch_encode(srslte_pdsch_t*     q,
       return SRSLTE_ERROR_INVALID_INPUTS;
     }
 
+    // Identical sub-expressions
     if (cfg->grant.nof_re > q->max_re || cfg->grant.nof_re > q->max_re) {
       ERROR("Error too many RE per subframe (%d). PDSCH configured for %d RE (%d PRB)\n",
             cfg->grant.nof_re,

--- a/lib/src/phy/phch/phich.c
+++ b/lib/src/phy/phch/phich.c
@@ -196,11 +196,6 @@ int srslte_phich_decode(srslte_phich_t*         q,
 
   uint32_t sf_idx = sf->tti % 10;
 
-  if (sf_idx >= SRSLTE_NOF_SF_X_FRAME) {
-    ERROR("Invalid nslot %d\n", sf_idx);
-    return SRSLTE_ERROR_INVALID_INPUTS;
-  }
-
   if (SRSLTE_CP_ISEXT(q->cell.cp)) {
     if (n_phich.nseq >= SRSLTE_PHICH_EXT_NSEQUENCES) {
       ERROR("Invalid nseq %d\n", n_phich.nseq);
@@ -328,11 +323,6 @@ int srslte_phich_encode(srslte_phich_t*         q,
   }
 
   uint32_t sf_idx = sf->tti % 10;
-
-  if (sf_idx >= SRSLTE_NOF_SF_X_FRAME) {
-    ERROR("Invalid nslot %d\n", sf_idx);
-    return SRSLTE_ERROR_INVALID_INPUTS;
-  }
 
   if (SRSLTE_CP_ISEXT(q->cell.cp)) {
     if (n_phich.nseq >= SRSLTE_PHICH_EXT_NSEQUENCES) {

--- a/lib/src/phy/phch/pmch.c
+++ b/lib/src/phy/phch/pmch.c
@@ -73,7 +73,7 @@ static int pmch_cp(srslte_pmch_t* q, cf_t* input, cf_t* output, uint32_t lstart_
             in_ptr = &input[(lp * q->cell.nof_prb + n) * SRSLTE_NRE];
           }
           // This is a symbol in a normal PRB with or without references
-          if (l >= lstart && l < lend) {
+          if (l >= lstart) {
             if (SRSLTE_SYMBOL_HAS_REF_MBSFN(l,s)) {
               if (l == 0 && s == 1) {
                 offset = 1;

--- a/lib/src/phy/phch/prach.c
+++ b/lib/src/phy/phch/prach.c
@@ -637,9 +637,7 @@ int srslte_prach_detect_offset(srslte_prach_t* p,
           if (p->peak_values[j] > p->detect_factor * corr_ave) {
             //printf("saving prach correlation\n");
             //memcpy(save_corr, p->corr, p->N_zc*sizeof(float));
-            if (indices) {
-              indices[*n_indices] = (i * n_wins) + j;
-            }
+            indices[*n_indices] = (i * n_wins) + j;
             if (peak_to_avg) {
               peak_to_avg[*n_indices] = p->peak_values[j] / corr_ave;
             }

--- a/lib/src/phy/phch/pucch.c
+++ b/lib/src/phy/phch/pucch.c
@@ -572,7 +572,7 @@ static int encode_bits(srslte_pucch_cfg_t*   cfg,
 {
   if (format < SRSLTE_PUCCH_FORMAT_2) {
     memcpy(pucch_bits, uci_data->ack.ack_value, srslte_uci_cfg_total_ack(&cfg->uci_cfg) * sizeof(uint8_t));
-  } else if (format >= SRSLTE_PUCCH_FORMAT_2 && format < SRSLTE_PUCCH_FORMAT_3) {
+  } else if (format < SRSLTE_PUCCH_FORMAT_3) {
     /* Put RI (goes alone) */
     if (cfg->uci_cfg.cqi.ri_len) {
       uint8_t temp[2] = {uci_data->ri, 0};

--- a/lib/src/phy/phch/pusch.c
+++ b/lib/src/phy/phch/pusch.c
@@ -111,6 +111,8 @@ static int pusch_init(srslte_pusch_t* q, uint32_t max_prb, bool is_ue)
     
     bzero(q, sizeof(srslte_pusch_t));
     ret = SRSLTE_ERROR;
+    // MAX_PUSCH_RE(SRSLTE_CP_NORM)
+    // is the same as 2 * SRSLTE_CP_NORM_NSYMB * 12
     q->max_re = max_prb * MAX_PUSCH_RE(SRSLTE_CP_NORM);
 
     INFO("Init PUSCH: %d PRBs\n", max_prb);

--- a/lib/src/phy/phch/ra_ul.c
+++ b/lib/src/phy/phch/ra_ul.c
@@ -213,8 +213,6 @@ static void ul_fill_ra_mcs(srslte_ra_tb_t* tb, srslte_ra_tb_t* last_tb, uint32_t
     } else if (tb->mcs_idx < 29) {
       tb->mod = SRSLTE_MOD_64QAM;
       tb->tbs = srslte_ra_tbs_from_idx(tb->mcs_idx - 2, L_prb);
-    } else {
-      ERROR("Invalid MCS index %d\n", tb->mcs_idx);
     }
   } else if (tb->mcs_idx == 29 && cqi_request && L_prb <= 4) {
     // 8.6.1 and 8.6.2 36.213 second paragraph

--- a/lib/src/phy/phch/regs.c
+++ b/lib/src/phy/phch/regs.c
@@ -322,7 +322,7 @@ int regs_phich_init(srslte_regs_t* h, uint32_t phich_mi, bool mbsfn_or_sf1_6_tdd
       // Step 7
       if (h->phich_len == SRSLTE_PHICH_NORM) {
         li = 0;
-      } else if (h->phich_len == SRSLTE_PHICH_EXT && mbsfn_or_sf1_6_tdd) {
+      } else if (mbsfn_or_sf1_6_tdd) {
         li = (mi / 2 + i + 1) % 2;
       } else {
         li = i;
@@ -640,7 +640,7 @@ int regs_reg_init(srslte_regs_reg_t *reg, uint32_t symbol, uint32_t nreg, uint32
   case 2:
     reg->k0 = k0 + nreg * 6;
     /* there are two references in the middle */
-    j = z = 0;
+    j = 0;
     for (i = 0; i < vo; i++) {
       reg->k[j] = k0 + nreg * 6 + i;
       j++;

--- a/lib/src/phy/phch/sch.c
+++ b/lib/src/phy/phch/sch.c
@@ -322,7 +322,7 @@ bool decode_tb_cb(srslte_sch_t *q,
 
       uint32_t rlen       = cb_segm->C==1?cb_len:(cb_len-24);
       uint32_t Gp         = nof_e_bits / Qm;
-      uint32_t gamma      = cb_segm->C>0?Gp%cb_segm->C:Gp;
+      uint32_t gamma      = Gp%cb_segm->C;
       uint32_t n_e        = Qm * (Gp/cb_segm->C);
 
       uint32_t rp   = cb_idx*n_e;

--- a/lib/src/phy/resampling/interp.c
+++ b/lib/src/phy/resampling/interp.c
@@ -187,7 +187,6 @@ int srslte_interp_linear_init(srslte_interp_lin_t *q, uint32_t vector_len, uint3
     q->ramp = srslte_vec_malloc(M * sizeof(float));
     if (!q->ramp) {
       perror("malloc");
-      free(q->ramp);
       free(q->diff_vec);
       return SRSLTE_ERROR; 
     }    

--- a/lib/src/phy/sync/nsss.c
+++ b/lib/src/phy/sync/nsss.c
@@ -270,12 +270,8 @@ int srslte_nsss_sync_find(
     }
 
     // set remaining return values
-    if (sfn_partial) {
-      *sfn_partial = 0; // we only search for the first of the four possible shifts
-    }
-    if (corr_peak_value) {
-      *corr_peak_value = peak_value;
-    }
+    *sfn_partial = 0; // we only search for the first of the four possible shifts
+    *corr_peak_value = peak_value;
   }
   return ret;
 }

--- a/lib/src/phy/ue/ue_mib.c
+++ b/lib/src/phy/ue/ue_mib.c
@@ -48,6 +48,8 @@ int srslte_ue_mib_init(srslte_ue_mib_t * q,
       goto clean_exit;
     }
 
+    // SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM)
+    // second argument should be variable, otherwise value is fixed
     q->sf_symbols[0] = srslte_vec_malloc(SRSLTE_SF_LEN_RE(max_prb, SRSLTE_CP_NORM) * sizeof(cf_t));
     if (!q->sf_symbols[0]) {
       perror("malloc");
@@ -261,7 +263,7 @@ int srslte_ue_mib_sync_decode(srslte_ue_mib_sync_t * q,
         }
         nof_frames++;
       }
-    } while (mib_ret == SRSLTE_UE_MIB_NOTFOUND && ret >= 0 && nof_frames < max_frames_timeout);
+    } while (mib_ret == SRSLTE_UE_MIB_NOTFOUND && nof_frames < max_frames_timeout);
     if (mib_ret < 0) {
       ret = mib_ret; 
     }

--- a/lib/src/phy/ue/ue_sync.c
+++ b/lib/src/phy/ue/ue_sync.c
@@ -790,7 +790,9 @@ int srslte_ue_sync_zerocopy(srslte_ue_sync_t* q, cf_t* input_buffer[SRSLTE_MAX_P
 
           {
             // Process AGC every period
-            if (q->do_agc && (q->agc_period == 0 || (q->agc_period && (q->frame_total_cnt % q->agc_period) == 0))) {
+            // q->agc_period is unsigned int [0, MAX(Int)]
+            // as we are checking it against 0 first later it can't be < 0
+            if (q->do_agc && (q->agc_period == 0 || ((q->frame_total_cnt % q->agc_period) == 0))) {
               srslte_agc_process(&q->agc, input_buffer[0], q->sf_len);
             }
 

--- a/lib/src/phy/ue/ue_ul.c
+++ b/lib/src/phy/ue/ue_ul.c
@@ -635,7 +635,7 @@ static uint32_t get_npucch_cs(srslte_pucch_cfg_t* cfg, srslte_uci_cfg_t* uci_cfg
         b[1] = (uint8_t)((b[3] != 1 ? 0 : 1) & ((b[1] != 1 ? 0 : 1) ^ (b[2] != 1 ? 0 : 1)));
       } else {
         /* n_pucch1_3 */
-        b[0] = (uint8_t)((b[1] != 1 ? 0 : 1) & (b[0] != 1 ? 1 : 0));
+        b[0] = (uint8_t)((b[1] != 1 ? 0 : 1) & (1));
         b[1] = (uint8_t)((b[3] != 1 ? 0 : 1) & ((b[1] != 1 ? 0 : 1) ^ (b[2] != 1 ? 0 : 1)));
       }
       break;

--- a/lib/src/upper/rlc_am.cc
+++ b/lib/src/upper/rlc_am.cc
@@ -1070,7 +1070,7 @@ int rlc_am::rlc_am_tx::required_buffer_size(rlc_amd_retx_t retx)
 
     upper += old_header.li[i];
 
-    if (upper > retx.so_start && lower < retx.so_end) {  // Current SDU is needed
+    if (upper > retx.so_start) {  // Current SDU is needed
       li = upper - lower;
       if (upper > retx.so_end) {
         li -= upper - retx.so_end;

--- a/srsepc/src/hss/hss.cc
+++ b/srsepc/src/hss/hss.cc
@@ -130,6 +130,7 @@ bool hss::read_db_file(std::string db_filename)
         ue_ctx->algo = HSS_ALGO_MILENAGE;
       } else {
         m_hss_log->error("Neither XOR nor MILENAGE configured.\n");
+        delete ue_ctx;
         return false;
       }
       ue_ctx->imsi         = atoll(split[2].c_str());
@@ -143,6 +144,7 @@ bool hss::read_db_file(std::string db_filename)
         get_uint_vec_from_hex_str(split[5], ue_ctx->opc, 16);
       } else {
         m_hss_log->error("Neither OP nor OPc configured.\n");
+        delete ue_ctx;
         return false;
       }
       get_uint_vec_from_hex_str(split[6], ue_ctx->amf, 2);
@@ -169,10 +171,12 @@ bool hss::read_db_file(std::string db_filename)
             m_hss_log->info("static ip addr %s\n", ue_ctx->static_ip_addr.c_str());
           } else {
             m_hss_log->info("duplicate static ip addr %s\n", split[9].c_str());
+            delete ue_ctx;
             return false;
           }
         } else {
           m_hss_log->info("invalid static ip addr %s, %s\n", split[9].c_str(), strerror(errno));
+          delete ue_ctx;
           return false;
         }
       }

--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -424,7 +424,6 @@ bool nas::handle_guti_attach_request_known_ue(nas*                              
     emm_ctx->attach_type = attach_req.eps_attach_type;
 
     // Set eNB information
-    ecm_ctx->enb_ue_s1ap_id = enb_ue_s1ap_id;
     memcpy(&ecm_ctx->enb_sri, enb_sri, sizeof(struct sctp_sndrcvinfo));
 
     // Save whether secure ESM information transfer is necessary

--- a/srsepc/src/spgw/gtpu.cc
+++ b/srsepc/src/spgw/gtpu.cc
@@ -245,7 +245,7 @@ void spgw::gtpu::handle_sgi_pdu(srslte::byte_buffer_t* msg)
     m_gtpc->send_downlink_data_notification(spgw_teid);
     m_gtpc->queue_downlink_packet(spgw_teid, msg);
     return;
-  } else if (usr_found == false && ctr_found == true) {
+  } else if (usr_found == true && ctr_found == false) {
     m_gtpu_log->error("User plane tunnel found without a control plane tunnel present.\n");
     goto pkt_discard_out;
   } else {


### PR DESCRIPTION
rrc_asn1_utils.cc:
 - asn1_type.sched_request_cfg_present condition already verified
 - asn1_type.pdsch_cfg_ded_present condition already verified

liblte_s1ap.cc:
 - ie->len < 128 is always true
 - ie->n_octets < 128 is always true

liblte_m2ap.cc:
 - ie->iE_Extensions_present is always true

enb_dl.c:
 - There are identical sub-expressions to the left and to the right of the macro

chest_dl.c:
 - There are identical sub-expressions to the left and to the right of the macro

chest_ul.c:
 - There are identical sub-expressions to the left and to the right of the macro

refsignal_dl.c:
 - Expression 'ret == - 1' is always false.

refsignal_ul.c:
 - sf_idx < 10 is always true
 - subframe_config == 14 is always true

sequence.c:
 - len > q->max_len is always false

rm_turbo.c:
 - rm_turbo_tables_generated variable is assigned values twice successively

cqi.c:
 - The ?: operator has a lower priority than the + operator
 - M_ri is always true

precoding.c:
 - nof_rxant <= 2 is always true
 - csi[i] variable is assigned values twice successively
 - nof_layers <= 4 is always true

phich.c:
 - sf_idx >= 10 is always false

pdsch.c:
 - There are identical expressions 'cfg->grant.nof_re > q->max_re' in the '||' operator

pmch.c:
 - l < lend is always true

prach.c:
 - indices is always true

pusch.c:
 - Macro parameter is the same as defined inside

pucch.c:
 - format >= SRSLTE_PUCCH_FORMAT_2 is always true

regs.c:
 - h->phich_len == SRSLTE_PHICH_EXT is always true
 - z variable is assigned values twice successively

ra_ul.c:
 - tb->mcs_idx < 29 is always true

sch.c:
 - cb_segm->C > 0 is always true

npss.c:
 - signal[l * 11 + n] variable is assigned values twice successively

nsss.c:
 - sfn_partial is always true
 - corr_peak_value is always true

dft_fftw.c:
 - exited without calling the pthread_mutex_unlock

netsink.c:
 - q->connected is always true

interp.c:
 - null pointer is passed into free function

ue_mib.c:
 - There are identical expressions in the '==' operator (macro)
 - ret >= 0 is always true

ue_sync.c:
 - q->agc_period is always true

ue_ul.c:
 - b[0] != 1 is always true

threads.c:
 - attr_enable is always true

pdu_queue.cc:
 - pointer used before verified against nullptr

chest_test_ul.c:
 - t == 1 is always false
 - !t is always false

pmi_select_test.c:
 - There are identical expressions in the '==' operator (macro)

rlc_am.cc:
 - lower < retx.so_end is always true

gtpu.cc:
 - Identical logical expression in conditional if..else

nas.cc:
 - ecm_ctx->enb_ue_s1ap_id variable is assigned values twice successively

hss.cc:
 - function exits without deleteing the ue_ctx pointer
