### PR TITLE
enb: fix list of logging layers in conf example

### DIFF
--- a/srsenb/enb.conf.example
+++ b/srsenb/enb.conf.example
@@ -116,7 +116,7 @@ filename = /tmp/enb.pcap
 # configured.
 # Format: e.g. phy_hex_limit = 32
 #
-# Logging layers: rf, phy, mac, rlc, pdcp, rrc, nas, gtpu, usim, all
+# Logging layers: rf, phy, phy_lib, mac, rlc, pdcp, rrc, gtpu, s1ap, all
 # Logging levels: debug, info, warning, error, none
 #
 # filename: File path to use for log output. Can be set to stdout


### PR DESCRIPTION
Added 'phy_lib' and 's1ap', removed 'nas'.

As per the srsenb help:
```
  $ srsenb --help | grep level | grep log
    --log.rf_level arg                    RF log level
    --log.phy_level arg                   PHY log level
    --log.phy_lib_level arg (=none)       PHY lib log level
    --log.mac_level arg                   MAC log level
    --log.rlc_level arg                   RLC log level
    --log.pdcp_level arg                  PDCP log level
    --log.rrc_level arg                   RRC log level
    --log.gtpu_level arg                  GTPU log level
    --log.s1ap_level arg                  S1AP log level
    --log.all_level arg (=info)           ALL log level
```