### PR TITLE
Always print full RRC messages in UE/eNB

### DIFF
--- a/srsenb/src/stack/rrc/rrc.cc
+++ b/srsenb/src/stack/rrc/rrc.cc
@@ -166,8 +166,13 @@ void rrc::log_rrc_message(const std::string& source, const direction_t dir, cons
   } else if (rrc_log->get_level() >= srslte::LOG_LEVEL_DEBUG) {
     asn1::json_writer json_writer;
     msg.to_json(json_writer);
-    rrc_log->debug_hex(pdu->msg, pdu->N_bytes, "%s - %s %s (%d B)\n", source.c_str(), dir == Tx ? "Tx" : "Rx",
-                       msg.msg.c1().type().to_string().c_str(), pdu->N_bytes);
+    rrc_log->debug_hex(pdu->msg,
+                       pdu->N_bytes,
+                       "%s - %s %s (%d B)\n",
+                       source.c_str(),
+                       dir == Tx ? "Tx" : "Rx",
+                       msg.msg.c1().type().to_string().c_str(),
+                       pdu->N_bytes);
     rrc_log->debug_long("Content:\n%s\n", json_writer.to_string().c_str());
   }
 }

--- a/srsenb/src/stack/rrc/rrc.cc
+++ b/srsenb/src/stack/rrc/rrc.cc
@@ -168,7 +168,7 @@ void rrc::log_rrc_message(const std::string& source, const direction_t dir, cons
     msg.to_json(json_writer);
     rrc_log->debug_hex(pdu->msg, pdu->N_bytes, "%s - %s %s (%d B)\n", source.c_str(), dir == Tx ? "Tx" : "Rx",
                        msg.msg.c1().type().to_string().c_str(), pdu->N_bytes);
-    rrc_log->debug("Content:\n%s\n", json_writer.to_string().c_str());
+    rrc_log->debug_long("Content:\n%s\n", json_writer.to_string().c_str());
   }
 }
 

--- a/srsue/src/stack/rrc/rrc.cc
+++ b/srsue/src/stack/rrc/rrc.cc
@@ -1513,7 +1513,7 @@ void rrc::write_pdu_bcch_bch(unique_byte_buffer_t pdu)
     asn1::json_writer json_writer;
     bch_msg.to_json(json_writer);
     rrc_log->debug_hex(pdu->msg, pdu->N_bytes, "BCCH-BCH - Rx (%d B)\n", pdu->N_bytes);
-    rrc_log->debug("Content:\n%s\n", json_writer.to_string().c_str());
+    rrc_log->debug_long("Content:\n%s\n", json_writer.to_string().c_str());
   }
 
   // Do we need to do something with BCH?


### PR DESCRIPTION
Most RRC messages were not being fully printed because the JSON printer does a truly bad job indenting the fields with spaces, so the limit of 1024 characters was reached early. Just ignore the limit and always print full JSON contents.