### PR TITLE
fixing two more issues reported by lgtm in asn1 libs

### DIFF
--- a/lib/include/srslte/asn1/asn1_utils.h
+++ b/lib/include/srslte/asn1/asn1_utils.h
@@ -581,7 +581,7 @@ public:
   {
     if (s.size() != N) {
       srsasn_log_print(
-          LOG_LEVEL_ERROR, "The provided string size=%d does not match the bit string size=%d\n", s.size(), N);
+          LOG_LEVEL_ERROR, "The provided string size=%zd does not match the bit string size=%d\n", s.size(), N);
     }
     memset(&octets_[0], 0, nof_octets());
     for (uint32_t i = 0; i < N; ++i)

--- a/lib/src/asn1/rrc_asn1_utils.cc
+++ b/lib/src/asn1/rrc_asn1_utils.cc
@@ -151,6 +151,7 @@ srslte::rlc_config_t make_rlc_config_t(const asn1::rrc::srb_to_add_mod_s& asn1_t
   } else {
     asn1::rrc::rrc_log_print(
         asn1::LOG_LEVEL_ERROR, "SRB %d does not support default initialization type\n", asn1_type.srb_id);
+    return rlc_config_t();
   }
 }
 


### PR DESCRIPTION
the last two fixes to remove all critical warnings from lgtm, of course, we need to backport those to the asn_libs.