### PR TITLE
minor typo fix in lib, eNB and UE

### DIFF
--- a/lib/src/upper/rlc_um.cc
+++ b/lib/src/upper/rlc_um.cc
@@ -696,7 +696,7 @@ void rlc_um::rlc_um_rx::handle_data_pdu(uint8_t *payload, uint32_t nof_bytes)
   // Write to rx window
   pdu.buf = allocate_unique_buffer(*pool);
   if (!pdu.buf) {
-    log->error("Discarting packet: no space in buffer pool\n");
+    log->error("Discarding packet: no space in buffer pool\n");
     return;
   }
   memcpy(pdu.buf->msg, payload, nof_bytes);

--- a/srsenb/src/stack/mac/scheduler.cc
+++ b/srsenb/src/stack/mac/scheduler.cc
@@ -933,7 +933,7 @@ int sched::dl_rach_info(uint32_t tti, uint32_t ra_id, uint16_t rnti, uint32_t es
       return 0;
     }
   }
-  Warning("SCHED: New RACH discarted because maximum number of pending RAR exceeded (%d)\n", SCHED_MAX_PENDING_RAR);
+  Warning("SCHED: New RACH discarded because maximum number of pending RAR exceeded (%d)\n", SCHED_MAX_PENDING_RAR);
   return -1;
 }
 

--- a/srsenb/src/stack/mac/scheduler_harq.cc
+++ b/srsenb/src/stack/mac/scheduler_harq.cc
@@ -113,7 +113,7 @@ void harq_proc::set_ack_common(uint32_t tb_idx, bool ack_)
   ack_state[tb_idx] = ack_ ? ACK : NACK;
   log_h->debug("ACK=%d received pid=%d, tb_idx=%d, n_rtx=%d, max_retx=%d\n", ack_, id, tb_idx, n_rtx[tb_idx], max_retx);
   if (!ack_ && (n_rtx[tb_idx] + 1 >= max_retx)) {
-    Warning("SCHED: discarting TB %d pid=%d, tti=%d, maximum number of retx exceeded (%d)\n", tb_idx, id, tti, max_retx);
+    Warning("SCHED: discarding TB %d pid=%d, tti=%d, maximum number of retx exceeded (%d)\n", tb_idx, id, tti, max_retx);
     active[tb_idx] = false;
   } else if (ack_) {
     active[tb_idx] = false;

--- a/srsue/src/phy/sync.cc
+++ b/srsue/src/phy/sync.cc
@@ -584,7 +584,7 @@ void sync::run_thread()
           if (current_srate > 0) {
             nsamples = current_srate/1000;
           }
-          Debug("Discarting %d samples\n", nsamples);
+          Debug("Discarding %d samples\n", nsamples);
           srslte_timestamp_t rx_time;
           if (!radio_h->rx_now(0, dummy_buffer, nsamples, &rx_time)) {
             log_h->console("SYNC:  Receiving from radio while in IDLE_RX\n");

--- a/srsue/src/stack/mac/dl_harq.cc
+++ b/srsue/src/stack/mac/dl_harq.cc
@@ -319,7 +319,7 @@ void dl_harq_entity::dl_harq_process::dl_tb_process::new_grant_dl(mac_interface_
     action->tb[tid].rv            = cur_grant.tb[tid].rv;
     action->tb[tid].softbuffer.rx = &softbuffer;
   } else {
-    Warning("DL PID %d: Received duplicate TB%d. Discarting and retransmitting ACK (n_retx=%d, reset=%s)\n",
+    Warning("DL PID %d: Received duplicate TB%d. Discarding and retransmitting ACK (n_retx=%d, reset=%s)\n",
             pid,
             tid,
             n_retx,

--- a/srsue/src/stack/mac/ul_harq.cc
+++ b/srsue/src/stack/mac/ul_harq.cc
@@ -209,7 +209,7 @@ void ul_harq_entity::ul_harq_process::new_grant_ul(mac_interface_phy_lte::mac_gr
 
     // Check maximum retransmissions, do not consider last retx ACK
     if (current_tx_nb >= max_retx && !grant.hi_value) {
-      Info("UL %d:  Maximum number of ReTX reached (%d). Discarting TB.\n", pid, max_retx);
+      Info("UL %d:  Maximum number of ReTX reached (%d). Discarding TB.\n", pid, max_retx);
       if (grant_is_rar()) {
         harq_entity->ra_procedure->harq_max_retx();
       }


### PR DESCRIPTION
Replacing "discart" with "discard"