### PR TITLE
Support multiple SoapySDR devices using id=# device_arg

### DIFF
--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -309,6 +309,7 @@ int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
     dev_id = strtol(dev_str, NULL, 0);
     if (dev_id < 0 || dev_id > 10) {
       ERROR("Failed to set device. Using 0 as default.\n");
+      dev_id = 0;
     }
     remove_substring(args, dev_arg);
     remove_substring(args, dev_str);

--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -299,9 +299,9 @@ int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
   }
 
   // Select Soapy device by id
-  const char dev_arg[]   = "id=";
-  char*      dev_ptr     = strstr(args, dev_arg);
-  int        dev_id      = 0;
+  const char dev_arg[] = "id=";
+  char* dev_ptr = strstr(args, dev_arg);
+  int dev_id = 0;
   if (dev_ptr) {
     char dev_str[64] = {0};
     copy_subdev_string(dev_str, dev_ptr + strnlen(dev_arg, 64));

--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -300,8 +300,8 @@ int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
 
   // Select Soapy device by id
   const char dev_arg[] = "id=";
-  char* dev_ptr = strstr(args, dev_arg);
-  int dev_id = 0;
+  char*      dev_ptr   = strstr(args, dev_arg);
+  int        dev_id    = 0;
   if (dev_ptr) {
     char dev_str[64] = {0};
     copy_subdev_string(dev_str, dev_ptr + strnlen(dev_arg, 64));

--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -298,7 +298,22 @@ int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
     printf("\n");
   }
 
-  SoapySDRDevice* sdr = SoapySDRDevice_make(&(soapy_args[0]));
+  // Select Soapy device by id
+  const char dev_arg[]   = "soapy=";
+  char       dev_str[64] = {0};
+  char*      dev_ptr     = strstr(args, dev_arg);
+  int        dev_id      = -1;
+  if (dev_ptr) {
+    copy_subdev_string(dev_str, dev_ptr + strlen(dev_arg));
+    printf("Selecting Soapy device: %s\n", dev_str);
+    if ((dev_id = atoi(dev_str)) < 0) {
+      ERROR("Failed to set device.\n");
+    }
+    remove_substring(args, dev_arg);
+    remove_substring(args, dev_str);
+  }
+
+  SoapySDRDevice* sdr = SoapySDRDevice_make(&(soapy_args[dev_id]));
   if (sdr == NULL) {
     printf("Failed to create Soapy object\n");
     return SRSLTE_ERROR;

--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -299,11 +299,11 @@ int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
   }
 
   // Select Soapy device by id
-  const char dev_arg[]   = "soapy=";
+  const char dev_arg[]   = "id=";
   char*      dev_ptr     = strstr(args, dev_arg);
   int        dev_id      = 0;
   if (dev_ptr) {
-    char       dev_str[64] = {0};
+    char dev_str[64] = {0};
     copy_subdev_string(dev_str, dev_ptr + strnlen(dev_arg, 64));
     printf("Selecting Soapy device: %s\n", dev_str);
     dev_id = strtol(dev_str, NULL, 0);

--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -300,14 +300,15 @@ int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
 
   // Select Soapy device by id
   const char dev_arg[]   = "soapy=";
-  char       dev_str[64] = {0};
   char*      dev_ptr     = strstr(args, dev_arg);
-  int        dev_id      = -1;
+  int        dev_id      = 0;
   if (dev_ptr) {
-    copy_subdev_string(dev_str, dev_ptr + strlen(dev_arg));
+    char       dev_str[64] = {0};
+    copy_subdev_string(dev_str, dev_ptr + strnlen(dev_arg, 64));
     printf("Selecting Soapy device: %s\n", dev_str);
-    if ((dev_id = atoi(dev_str)) < 0) {
-      ERROR("Failed to set device.\n");
+    dev_id = strtol(dev_str, NULL, 0);
+    if (dev_id < 0 || dev_id > 10) {
+      ERROR("Failed to set device. Using 0 as default.\n");
     }
     remove_substring(args, dev_arg);
     remove_substring(args, dev_str);


### PR DESCRIPTION
This allows multiple SoapySDR devices to be addressed using the id=# device_arg.
This is useful in instances where the device you want to use is not #0, such as running concurrent eNB processes.