### PR TITLE
github: comment notice on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
+<!--
 Before filing an issue, search for solutions here:
 - srsLTE users mailing list (http://www.softwareradiosystems.com/mailman/listinfo/srslte-users)
+-->
 
 ## Issue Description ##
 [Describe the issue in detail]


### PR DESCRIPTION
This way users don't need to remove the text from the issue body, it
will be ignored automatically.

Signed-off-by: Filipe Laíns <lains@archlinux.org>