### PR TITLE
More generous CSFB

### DIFF
--- a/srsenb/sib.conf.example
+++ b/srsenb/sib.conf.example
@@ -9,7 +9,7 @@ sib1 =
     (
         {
             si_periodicity = 16;
-            si_mapping_info = [7]; // comma-separated array of SIB-indexes (from 3 to 13). 
+            si_mapping_info = []; // comma-separated array of SIB-indexes (from 3 to 13). 
             // Leave empty or commented to just scheduler sib2
         }
     );

--- a/srsenb/sib.conf.example
+++ b/srsenb/sib.conf.example
@@ -9,7 +9,7 @@ sib1 =
     (
         {
             si_periodicity = 16;
-            si_mapping_info = []; // comma-separated array of SIB-indexes (from 3 to 13). 
+            si_mapping_info = [7]; // comma-separated array of SIB-indexes (from 3 to 13). 
             // Leave empty or commented to just scheduler sib2
         }
     );
@@ -114,5 +114,23 @@ sib2 =
     };
 
     time_alignment_timer = "INFINITY"; // use "sf500", "sf750", etc.
+};
+
+sib7 =
+{
+    t_resel_geran = 1;
+    carrier_freqs_info_list =
+    (
+        {
+            cell_resel_prio = 0;
+            ncc_permitted = 255;
+            q_rx_lev_min = 0;
+            thresh_x_high = 2;
+            thresh_x_low = 2;
+
+            start_arfcn = 871;
+            band_ind = "dcs1800";
+        }
+    );
 };
 

--- a/srsenb/src/stack/rrc/rrc.cc
+++ b/srsenb/src/stack/rrc/rrc.cc
@@ -405,7 +405,6 @@ bool rrc::modify_ue_ctxt(uint16_t rnti, LIBLTE_S1AP_MESSAGE_UECONTEXTMODIFICATIO
   }
   if (msg->RegisteredLAI_present) {
     rrc_log->warning("Not handling RegisteredLAI\n");
-    err = true;
   }
   if (msg->SubscriberProfileIDforRFP_present) {
     rrc_log->warning("Not handling SubscriberProfileIDforRFP\n");


### PR DESCRIPTION
I've observed that srsenb will reject the UEContextModificationRequest produced by my test setup since it includes RegisteredLAI information. That srsenb does not explicitly handle RegisteredLAI is currently logged as a warning, thus it seems appropriate to remove the error indicator and allow the request to proceed.

Test setup:
- srsenb (LTE eNB)
- open5gs (LTE EPC)
- osmocom (GERAN)

Also including updated sib.conf with the necessary sib7.