### PR TITLE
Introduce the external NAS interface and RRCTL protocol

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build srsLTE on x86
         run: |
           sudo apt update
-          sudo apt install -y build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libconfig++-dev libsctp-dev colordiff ninja-build valgrind
+          sudo apt install -y build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libasio-dev libconfig++-dev libsctp-dev colordiff ninja-build valgrind
           mkdir build && cd build && cmake -DRF_FOUND=True -GNinja .. && ninja && ctest -T memcheck
   x86_ubuntu16_build:
     name: Build and test on x86 Ubuntu 16.04
@@ -25,7 +25,7 @@ jobs:
       - name: Build srsLTE on x86
         run: |
           sudo apt update
-          sudo apt install -y build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libconfig++-dev libsctp-dev colordiff ninja-build valgrind
+          sudo apt install -y build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libasio-dev libconfig++-dev libsctp-dev colordiff ninja-build valgrind
           mkdir build && cd build && cmake -DRF_FOUND=True -GNinja .. && ninja && ctest -T memcheck
           
   aarch64_ubuntu18_build:
@@ -40,5 +40,5 @@ jobs:
         distribution: ubuntu18.04
         run: |
           apt update
-          apt install -y build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libconfig++-dev libsctp-dev ninja-build
+          apt install -y build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libasio-dev libconfig++-dev libsctp-dev ninja-build
           ls -l && pwd && mkdir build && cd build && cmake -DRF_FOUND=True -GNinja .. && ninja

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,6 +8,7 @@ extraction:
          - libmbedtls-dev
          - libpcsclite-dev
          - libboost-program-options-dev
+         - libasio-dev
          - libconfig++-dev
          - libsctp-dev
          - libuhd-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 
 before_script:
    - sudo apt-get -qq update
-   - sudo apt-get install -qq build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libconfig++-dev libsctp-dev colordiff ninja-build
+   - sudo apt-get install -qq build-essential cmake libfftw3-dev libmbedtls-dev libpcsclite-dev libboost-program-options-dev libasio-dev libconfig++-dev libsctp-dev colordiff ninja-build
 
 language: cpp
         

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Build Instructions
 
 For example, on Ubuntu 17.04, one can install the required libraries with:
 ```
-sudo apt-get install cmake libfftw3-dev libmbedtls-dev libboost-program-options-dev libconfig++-dev libsctp-dev
+sudo apt-get install cmake libfftw3-dev libmbedtls-dev libboost-program-options-dev libasio-dev libconfig++-dev libsctp-dev
 ```
 or on Fedora:
 ```

--- a/cmake/modules/SRSLTEPackage.cmake
+++ b/cmake/modules/SRSLTEPackage.cmake
@@ -1,7 +1,7 @@
 SET(CPACK_PACKAGE_DESCRIPTION "srsLTE")
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "LTE library for SDR.")
 SET(CPACK_PACKAGE_NAME "srslte")
-SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.3.6), libgcc1 (>= 1:4.1), libboost-dev (>= 1.35)")
+SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.3.6), libgcc1 (>= 1:4.1), libboost-dev (>= 1.35) libasio-dev")
 
 SET(CPACK_PACKAGE_CONTACT "Ismael Gomez ")
 SET(CPACK_PACKAGE_VENDOR "Software Radio Systems Limited")
@@ -45,12 +45,12 @@ ENDIF()
 ########################################################################
 # Setup CPack Debian
 ########################################################################
-SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-dev")
+SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-dev libasio-dev")
 
 ########################################################################
 # Setup CPack RPM
 ########################################################################
-SET(CPACK_RPM_PACKAGE_REQUIRES "boost-devel")
+SET(CPACK_RPM_PACKAGE_REQUIRES "boost-devel libasio-dev")
 
 ########################################################################
 # Setup CPack NSIS

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends:
     libfftw3-dev,
     libmbedtls-dev,
     libboost-program-options-dev,
+    libasio-dev,
     libconfig++-dev,
     libsctp-dev,
     libuhd-dev,

--- a/lib/include/srslte/common/common.h
+++ b/lib/include/srslte/common/common.h
@@ -172,7 +172,7 @@ public:
 #endif
   }
 
-  void append_bytes(uint8_t* buf, uint32_t size)
+  void append_bytes(const uint8_t* buf, uint32_t size)
   {
     memcpy(&msg[N_bytes], buf, size);
     N_bytes += size;

--- a/lib/include/srslte/interfaces/rrc_interface_types.h
+++ b/lib/include/srslte/interfaces/rrc_interface_types.h
@@ -83,7 +83,7 @@ struct plmn_id_t {
     }
     return SRSLTE_SUCCESS;
   }
-  std::pair<uint16_t, uint16_t> to_number()
+  std::pair<uint16_t, uint16_t> to_number() const
   {
     uint16_t mcc_num, mnc_num;
     srslte::bytes_to_mcc(&mcc[0], &mcc_num);

--- a/srsue/hdr/stack/ue_stack_base.h
+++ b/srsue/hdr/stack/ue_stack_base.h
@@ -64,6 +64,7 @@ typedef struct {
   usim_args_t      usim;
   rrc_args_t       rrc;
   std::string      ue_category_str;
+  nas_ext_args_t   nas_ext;
   nas_args_t       nas;
   gw_args_t        gw;
 } stack_args_t;

--- a/srsue/hdr/stack/ue_stack_lte.h
+++ b/srsue/hdr/stack/ue_stack_lte.h
@@ -37,6 +37,7 @@
 #include "srslte/upper/pdcp.h"
 #include "srslte/upper/rlc.h"
 #include "upper/nas.h"
+#include "upper/nas_ext.h"
 #include "upper/usim.h"
 
 #include "srslte/common/buffer_pool.h"

--- a/srsue/hdr/stack/ue_stack_lte.h
+++ b/srsue/hdr/stack/ue_stack_lte.h
@@ -153,8 +153,10 @@ private:
   srslte::rlc                rlc;
   srslte::pdcp               pdcp;
   srsue::rrc                 rrc;
-  srsue::nas                 nas;
   std::unique_ptr<usim_base> usim;
+
+  // NAS implementation (built-in or external)
+  std::unique_ptr<srsue::nas_base> nas;
 
   // RAT-specific interfaces
   phy_interface_stack_lte* phy = nullptr;

--- a/srsue/hdr/stack/upper/nas_common.h
+++ b/srsue/hdr/stack/upper/nas_common.h
@@ -38,6 +38,15 @@ public:
   std::string eea;
 };
 
+class nas_ext_args_t
+{
+public:
+  nas_ext_args_t() : enable(false) {}
+
+  bool        enable;
+  std::string sock_path;
+};
+
 // EMM states (3GPP 24.302 v10.0.0)
 typedef enum {
   EMM_STATE_NULL = 0,

--- a/srsue/hdr/stack/upper/nas_ext.h
+++ b/srsue/hdr/stack/upper/nas_ext.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#ifndef SRSUE_NAS_EXT_H
+#define SRSUE_NAS_EXT_H
+
+#include "srslte/common/buffer_pool.h"
+#include "srslte/common/common.h"
+#include "srslte/common/log.h"
+#include "srslte/common/nas_pcap.h"
+#include "srslte/common/security.h"
+#include "srslte/common/stack_procedure.h"
+#include "srslte/interfaces/ue_interfaces.h"
+
+#include "srsue/hdr/stack/upper/nas.h"
+#include "srsue/hdr/stack/upper/nas_common.h"
+#include "srsue/hdr/stack/upper/nas_ext.h"
+#include "srsue/hdr/stack/upper/nas_metrics.h"
+
+using srslte::byte_buffer_t;
+
+namespace srsue {
+
+class nas_ext : public nas_base
+{
+public:
+  nas_ext(srslte::log* log_, srslte::timer_handler* timers_, const nas_ext_args_t& cfg_) :
+    nas_base::nas_base(log_, timers_), cfg(cfg_){};
+
+  void init(usim_interface_nas* usim_, rrc_interface_nas* rrc_, gw_interface_nas* gw_);
+  void get_metrics(nas_metrics_t* m);
+  void stop();
+
+  // RRC interface
+  void     left_rrc_connected();
+  bool     paging(srslte::s_tmsi_t* ue_identity);
+  void     set_barring(barring_t barring);
+  void     write_pdu(uint32_t lcid, srslte::unique_byte_buffer_t pdu);
+  uint32_t get_k_enb_count();
+  bool     is_attached();
+  bool     get_k_asme(uint8_t* k_asme_, uint32_t n);
+  uint32_t get_ipv4_addr();
+  bool     get_ipv6_addr(uint8_t* ipv6_addr);
+
+  void plmn_search_completed(const rrc_interface_nas::found_plmn_t found_plmns[rrc_interface_nas::MAX_FOUND_PLMNS],
+                             int                                   nof_plmns) final;
+  bool connection_request_completed(bool outcome) final;
+  void run_tti(uint32_t tti) final;
+
+  // UE interface
+  void start_attach_request(srslte::proc_state_t* result, srslte::establishment_cause_t cause_) final;
+  bool detach_request(const bool switch_off) final;
+
+  // timer callback
+  void timer_expired(uint32_t timeout_id);
+
+private:
+  nas_ext_args_t cfg = {};
+};
+
+} // namespace srsue
+
+#endif // SRSUE_NAS_EXT_H

--- a/srsue/hdr/stack/upper/nas_ext.h
+++ b/srsue/hdr/stack/upper/nas_ext.h
@@ -37,6 +37,7 @@
 #include "srsue/hdr/stack/upper/nas_ext.h"
 #include "srsue/hdr/stack/upper/nas_extif.h"
 #include "srsue/hdr/stack/upper/nas_metrics.h"
+#include "srsue/hdr/stack/upper/rrctl.h"
 
 using srslte::byte_buffer_t;
 
@@ -80,6 +81,17 @@ private:
 
   // Interface to an external NAS entity
   std::unique_ptr<nas_extif_base> iface;
+
+  // RRCTL message handlers
+  void handle_rrctl_reset(rrctl::proto::msg_disc disc, const uint8_t* msg, size_t len);
+  void handle_rrctl_plmn_search(rrctl::proto::msg_disc disc, const uint8_t* msg, size_t len);
+  void handle_rrctl_plmn_select(rrctl::proto::msg_disc disc, const uint8_t* msg, size_t len);
+  void handle_rrctl_conn_establish(rrctl::proto::msg_disc disc, const uint8_t* msg, size_t len);
+  void handle_rrctl_conn_release(rrctl::proto::msg_disc disc, const uint8_t* msg, size_t len);
+  void handle_rrctl_data(rrctl::proto::msg_disc disc, const uint8_t* msg, size_t len);
+
+  void rrctl_send_confirm(rrctl::proto::msg_type type);
+  void rrctl_send_error(rrctl::proto::msg_type type);
 };
 
 } // namespace srsue

--- a/srsue/hdr/stack/upper/nas_ext.h
+++ b/srsue/hdr/stack/upper/nas_ext.h
@@ -35,6 +35,7 @@
 #include "srsue/hdr/stack/upper/nas.h"
 #include "srsue/hdr/stack/upper/nas_common.h"
 #include "srsue/hdr/stack/upper/nas_ext.h"
+#include "srsue/hdr/stack/upper/nas_extif.h"
 #include "srsue/hdr/stack/upper/nas_metrics.h"
 
 using srslte::byte_buffer_t;
@@ -76,6 +77,9 @@ public:
 
 private:
   nas_ext_args_t cfg = {};
+
+  // Interface to an external NAS entity
+  std::unique_ptr<nas_extif_base> iface;
 };
 
 } // namespace srsue

--- a/srsue/hdr/stack/upper/nas_extif.h
+++ b/srsue/hdr/stack/upper/nas_extif.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#ifndef SRSUE_NAS_EXTIF_H
+#define SRSUE_NAS_EXTIF_H
+
+#include "srslte/common/common.h"
+#include "srslte/common/log.h"
+#include "srslte/common/threads.h"
+
+using srslte::byte_buffer_t;
+
+namespace srsue {
+
+// Abstract class for an external interface
+class nas_extif_base : public thread
+{
+public:
+  using recv_cb_t = std::function<void(const srslte::byte_buffer_t&)>;
+
+  nas_extif_base(srslte::log* log_, recv_cb_t recv_cb_) :
+    nas_log(log_), recv_cb(std::move(recv_cb_)), thread("EXTIF"){};
+
+  // Interface for nas_ext
+  virtual void close(void)                             = 0;
+  virtual int  write(const srslte::byte_buffer_t& pdu) = 0;
+
+protected:
+  static const int IFACE_THREAD_PRIO = 65;
+  virtual void     run_thread()      = 0;
+  virtual void     stop()            = 0;
+  bool             running           = false;
+
+  srslte::log* nas_log = nullptr;
+  recv_cb_t    recv_cb;
+};
+
+} // namespace srsue
+
+#endif // SRSUE_NAS_EXTIF_H

--- a/srsue/hdr/stack/upper/nas_extif_unix.h
+++ b/srsue/hdr/stack/upper/nas_extif_unix.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#ifndef SRSUE_NAS_EXTIF_UNIX_H
+#define SRSUE_NAS_EXTIF_UNIX_H
+
+#include <boost/asio.hpp>
+
+#include "srslte/common/block_queue.h"
+#include "srslte/common/common.h"
+#include "srslte/common/log.h"
+
+#include "srsue/hdr/stack/upper/nas_extif.h"
+
+namespace srsue {
+
+// UNIX domain socket server
+class nas_extif_unix : public nas_extif_base
+{
+public:
+  nas_extif_unix(srslte::log* log_, recv_cb_t cb_, const std::string& sock_path_);
+
+  void close(void);
+  int  write(const srslte::byte_buffer_t& pdu);
+
+protected:
+  void run_thread(void);
+  void stop(void);
+
+private:
+  std::unique_ptr<boost::asio::local::stream_protocol::acceptor> acc;
+  std::unique_ptr<boost::asio::local::stream_protocol::socket>   sock;
+  boost::asio::io_context                                        io_ctx;
+  std::string                                                    sock_path;
+
+  srslte::block_queue<srslte::byte_buffer_t> tx_queue;
+  bool                                       has_connection;
+  uint8_t                                    buf[1024];
+
+  void handle_write(void);
+  void handle_read(void);
+  void accept_conn(void);
+};
+
+} // namespace srsue
+
+#endif // SRSUE_NAS_EXTIF_UNIX_H

--- a/srsue/hdr/stack/upper/rrctl.h
+++ b/srsue/hdr/stack/upper/rrctl.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#include <stdint.h>
+
+#include "srslte/common/common.h"
+#include "srslte/interfaces/ue_interfaces.h"
+
+namespace rrctl {
+
+namespace proto {
+
+  enum msg_type {
+    RRCTL_RESET = 0x00,
+    RRCTL_DATA,
+    RRCTL_PLMN_SEARCH,
+    RRCTL_PLMN_SELECT,
+    RRCTL_CONN_ESTABLISH,
+    RRCTL_CONN_RELEASE,
+  };
+
+  enum msg_disc {
+    RRCTL_REQ = 0x00,
+    RRCTL_IND = 0x01,
+    RRCTL_CNF = 0x02,
+    RRCTL_ERR = 0x03,
+  };
+
+  struct msg_hdr {
+    uint8_t type;
+    // FIXME: this is valid for little-endian machines only
+    uint8_t spare:6, disc:2;
+    uint16_t len;
+    uint8_t data[0];
+  } __attribute__((packed));
+
+  struct msg_plmn_search_res {
+    uint8_t nof_plmns;
+    struct plmn {
+      uint16_t mcc;
+      uint16_t mnc;
+      uint16_t tac;
+    } plmns[16];
+  } __attribute__((packed));
+
+  struct msg_plmn_select_req {
+    uint16_t mcc;
+    uint16_t mnc;
+  } __attribute__((packed));
+
+  struct msg_conn_establish_req {
+    uint8_t cause;
+    uint8_t pdu[0];
+  } __attribute__((packed));
+
+  struct msg_data {
+    uint32_t lcid;
+    uint8_t pdu[0];
+  } __attribute__((packed));
+
+  struct msg {
+    struct msg_hdr hdr;
+    union {
+      struct msg_data data;
+      struct msg_plmn_search_res plmn_search_res;
+      struct msg_plmn_select_req plmn_select_req;
+      struct msg_conn_establish_req conn_establish_req;
+    } u;
+  } __attribute__((packed));
+
+  std::string msg_hdr_desc(proto::msg_type type, proto::msg_disc disc, uint16_t len = 0);
+
+} // namespace proto
+
+namespace codec {
+
+class error : public std::runtime_error {
+public:
+  explicit error(const std::string& msg) : std::runtime_error(msg) {};
+};
+
+void enc_hdr(srslte::byte_buffer_t& buf,
+             proto::msg_type type,
+             proto::msg_disc disc,
+             uint16_t len = 0);
+const uint8_t* dec_hdr(const srslte::byte_buffer_t& buf,
+                       proto::msg_type& type,
+                       proto::msg_disc& disc,
+                       uint16_t& len);
+
+void enc_plmn_search_res(srslte::byte_buffer_t& buf,
+                         const srsue::rrc_interface_nas::found_plmn_t* plmns,
+                         size_t nof_plmns);
+
+void dec_plmn_select_req(std::pair<uint16_t, uint16_t>& mcc_mnc,
+                         const uint8_t* payload, size_t len);
+
+void dec_conn_establish_req(srslte::establishment_cause_t& cause,
+                            const uint8_t*& pdu, size_t& pdu_len,
+                            const uint8_t* payload, size_t len);
+
+void enc_data_ind(srslte::byte_buffer_t& buf,
+                  const uint8_t *pdu, size_t pdu_len,
+                  uint32_t lcid);
+
+} // namespace codec
+
+} // namespace rrctl

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -110,6 +110,9 @@ static int parse_args(all_args_t* args, int argc, char* argv[])
     ("nas.eia",               bpo::value<string>(&args->stack.nas.eia)->default_value("1,2,3"),  "List of integrity algorithms included in UE capabilities")
     ("nas.eea",               bpo::value<string>(&args->stack.nas.eea)->default_value("0,1,2,3"),  "List of ciphering algorithms included in UE capabilities")
 
+    ("extnas.enable", bpo::value<bool>(&args->stack.nas_ext.enable)->default_value(false), "Disable the built-in NAS implementation, provide external interface")
+    ("extnas.sock_path", bpo::value<string>(&args->stack.nas_ext.sock_path)->default_value("/tmp/ue_extnas.sock"), "UNIX socket path of the external interface")
+
     ("pcap.enable", bpo::value<bool>(&args->stack.pcap.enable)->default_value(false), "Enable MAC packet captures for wireshark")
     ("pcap.filename", bpo::value<string>(&args->stack.pcap.filename)->default_value("ue.pcap"), "MAC layer capture filename")
     ("pcap.nas_enable",   bpo::value<bool>(&args->stack.pcap.nas_enable)->default_value(false), "Enable NAS packet captures for wireshark")

--- a/srsue/src/stack/rrc/rrc.cc
+++ b/srsue/src/stack/rrc/rrc.cc
@@ -368,8 +368,8 @@ void rrc::new_phy_meas(float rsrp, float rsrq, uint32_t tti, int earfcn_i, int p
   }
   phy_meas_t new_meas = {rsrp, rsrq, tti, earfcn, pci};
   phy_meas_q.push(new_meas);
-  rrc_log->info("MEAS:  New measurement earfcn=%d, pci=%d (%s), rsrp=%.1f dBm.\n",
-                earfcn_i,
+  rrc_log->info("MEAS:  New measurement earfcn=%u, pci=%d (%s), rsrp=%.1f dBm.\n",
+                earfcn,
                 pci,
                 pci_i < 0 ? "serving" : "neighbour",
                 rsrp);

--- a/srsue/src/stack/ue_stack_lte.cc
+++ b/srsue/src/stack/ue_stack_lte.cc
@@ -116,8 +116,13 @@ int ue_stack_lte::init(const stack_args_t& args_, srslte::logger* logger_)
 
   // Should we use the built-in NAS implementation
   // or provide an external interface (RRCTL)?
-  std::unique_ptr<srsue::nas> nas_impl(new srsue::nas(&nas_log, &timers, args.nas));
-  nas = std::move(nas_impl);
+  if (args.nas_ext.enable) {
+    std::unique_ptr<srsue::nas_ext> nas_impl(new srsue::nas_ext(&nas_log, &timers, args.nas_ext));
+    nas = std::move(nas_impl);
+  } else {
+    std::unique_ptr<srsue::nas> nas_impl(new srsue::nas(&nas_log, &timers, args.nas));
+    nas = std::move(nas_impl);
+  }
 
   // Set up pcap
   if (args.pcap.enable) {

--- a/srsue/src/stack/upper/CMakeLists.txt
+++ b/srsue/src/stack/upper/CMakeLists.txt
@@ -18,7 +18,7 @@
 # and at http://www.gnu.org/licenses/.
 #
 
-set(SOURCES gw.cc nas.cc nas_ext.cc nas_extif.cc usim_base.cc usim.cc tft_packet_filter.cc)
+set(SOURCES gw.cc nas.cc nas_ext.cc nas_extif.cc rrctl.cc usim_base.cc usim.cc tft_packet_filter.cc)
 
 if(HAVE_PCSC)
   list(APPEND SOURCES "pcsc_usim.cc")

--- a/srsue/src/stack/upper/CMakeLists.txt
+++ b/srsue/src/stack/upper/CMakeLists.txt
@@ -18,7 +18,7 @@
 # and at http://www.gnu.org/licenses/.
 #
 
-set(SOURCES gw.cc nas.cc nas_ext.cc usim_base.cc usim.cc tft_packet_filter.cc)
+set(SOURCES gw.cc nas.cc nas_ext.cc nas_extif.cc usim_base.cc usim.cc tft_packet_filter.cc)
 
 if(HAVE_PCSC)
   list(APPEND SOURCES "pcsc_usim.cc")

--- a/srsue/src/stack/upper/CMakeLists.txt
+++ b/srsue/src/stack/upper/CMakeLists.txt
@@ -18,7 +18,7 @@
 # and at http://www.gnu.org/licenses/.
 #
 
-set(SOURCES gw.cc nas.cc usim_base.cc usim.cc tft_packet_filter.cc)
+set(SOURCES gw.cc nas.cc nas_ext.cc usim_base.cc usim.cc tft_packet_filter.cc)
 
 if(HAVE_PCSC)
   list(APPEND SOURCES "pcsc_usim.cc")

--- a/srsue/src/stack/upper/nas_ext.cc
+++ b/srsue/src/stack/upper/nas_ext.cc
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#include "srslte/common/buffer_pool.h"
+#include "srslte/common/common.h"
+#include "srslte/common/log.h"
+#include "srslte/common/nas_pcap.h"
+#include "srslte/common/security.h"
+#include "srslte/common/stack_procedure.h"
+#include "srslte/interfaces/ue_interfaces.h"
+
+#include "srsue/hdr/stack/upper/nas.h"
+#include "srsue/hdr/stack/upper/nas_common.h"
+#include "srsue/hdr/stack/upper/nas_ext.h"
+#include "srsue/hdr/stack/upper/nas_metrics.h"
+
+using namespace srslte;
+
+namespace srsue {
+
+void nas_ext::init(usim_interface_nas* usim_, rrc_interface_nas* rrc_, gw_interface_nas* gw_)
+{
+  usim = usim_;
+  rrc  = rrc_;
+  gw   = gw_;
+
+  // TODO: parse the configuration
+  // TODO: init the UNIX domain socket
+}
+
+void nas_ext::get_metrics(nas_metrics_t* m)
+{
+  nas_metrics_t metrics = {};
+  // FIXME: is there anything we could fill in?
+  *m = metrics;
+}
+
+void nas_ext::stop()
+{
+  // TODO: close the UNIX domain socket connection
+}
+
+/*******************************************************************************
+ * UE interface (dummy)
+ ******************************************************************************/
+
+void nas_ext::start_attach_request(srslte::proc_state_t* result, srslte::establishment_cause_t cause_)
+{
+  nas_log->info("The UE has requested us to perform Attach Request, however we ignore it\n");
+  if (result != nullptr) {
+    result->set_val();
+  }
+}
+
+bool nas_ext::detach_request(const bool switch_off)
+{
+  nas_log->info("The UE has requested us to perform Detach Request, however we ignore it\n");
+  return false;
+}
+
+void nas_ext::timer_expired(uint32_t timeout_id)
+{
+  nas_log->info("Timer id=%u is expired, however we ignore it\n", timeout_id);
+}
+
+/*******************************************************************************
+ * RRC interface
+ ******************************************************************************/
+
+// TODO: investigate the meaning of these signals
+void nas_ext::set_barring(barring_t barring) {}
+void nas_ext::run_tti(uint32_t tti) {}
+void nas_ext::left_rrc_connected() {}
+
+bool nas_ext::paging(srslte::s_tmsi_t* ue_identity)
+{
+  nas_log->info("Received paging from RRC\n");
+  // TODO: send PAGING.ind to the external entity
+  return false;
+}
+
+void nas_ext::write_pdu(uint32_t lcid, srslte::unique_byte_buffer_t pdu)
+{
+  nas_log->info_hex(pdu->msg, pdu->N_bytes, "Received DL %s PDU from RRC\n", rrc->get_rb_name(lcid).c_str());
+  // TODO: send DATA.ind to the external entity
+}
+
+uint32_t nas_ext::get_k_enb_count()
+{
+  // FIXME: we probably need to maintain a security context
+  return 0; // return a dummy value for now
+}
+
+bool nas_ext::is_attached()
+{
+  // FIXME: we probably need to maintain the state
+  return false; // return a dummy value for now
+}
+
+bool nas_ext::get_k_asme(uint8_t* k_asme_, uint32_t n)
+{
+  // FIXME: we probably need to maintain a security context
+  return false; // return a dummy value for now
+}
+
+uint32_t nas_ext::get_ipv4_addr()
+{
+  // FIXME: where can we get it? maybe from GW?
+  return 0x00000000;
+}
+
+bool nas_ext::get_ipv6_addr(uint8_t* ipv6_addr)
+{
+  // FIXME: where can we get it? maybe from GW?
+  return false;
+}
+
+void nas_ext::plmn_search_completed(
+    const rrc_interface_nas::found_plmn_t found_plmns[rrc_interface_nas::MAX_FOUND_PLMNS],
+    int                                   nof_plmns)
+{
+  nas_log->info("RRC has completed PLMN search, %d carriers found\n", nof_plmns);
+  // TODO: send PLMN_SEARCH.res to the external entity
+}
+
+bool nas_ext::connection_request_completed(bool outcome)
+{
+  nas_log->info("RRC has %s connection establisment\n", outcome ? "completed" : "failed");
+  // TODO: send CONN_ESTABLISH.res to the external entity
+  return false;
+}
+
+} // namespace srsue

--- a/srsue/src/stack/upper/nas_ext.cc
+++ b/srsue/src/stack/upper/nas_ext.cc
@@ -32,6 +32,7 @@
 #include "srsue/hdr/stack/upper/nas.h"
 #include "srsue/hdr/stack/upper/nas_common.h"
 #include "srsue/hdr/stack/upper/nas_ext.h"
+#include "srsue/hdr/stack/upper/nas_extif_unix.h"
 #include "srsue/hdr/stack/upper/nas_metrics.h"
 
 using namespace srslte;
@@ -44,8 +45,12 @@ void nas_ext::init(usim_interface_nas* usim_, rrc_interface_nas* rrc_, gw_interf
   rrc  = rrc_;
   gw   = gw_;
 
-  // TODO: parse the configuration
-  // TODO: init the UNIX domain socket
+  auto rx_cb = [this](const srslte::byte_buffer_t& pdu) {
+    // TODO: parse received payload
+  };
+
+  std::unique_ptr<nas_extif_unix> iface_(new nas_extif_unix(nas_log, rx_cb, cfg.sock_path));
+  iface = std::move(iface_);
 }
 
 void nas_ext::get_metrics(nas_metrics_t* m)
@@ -57,7 +62,9 @@ void nas_ext::get_metrics(nas_metrics_t* m)
 
 void nas_ext::stop()
 {
-  // TODO: close the UNIX domain socket connection
+  // Close the UNIX domain socket connection
+  iface->close();
+  iface.release();
 }
 
 /*******************************************************************************

--- a/srsue/src/stack/upper/nas_extif.cc
+++ b/srsue/src/stack/upper/nas_extif.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#include "srslte/common/common.h"
+#include "srslte/common/log.h"
+
+#include "srsue/hdr/stack/upper/nas_extif_unix.h"
+
+using namespace boost::asio::local;
+
+namespace srsue {
+
+nas_extif_unix::nas_extif_unix(srslte::log* log_, recv_cb_t cb_, const std::string& sock_path_) :
+  nas_extif_base(log_, cb_), sock_path(sock_path_), has_connection(false)
+{
+  nas_log->info("Init external NAS interface at '%s'\n", sock_path.c_str());
+
+  // Remove previous binding if present
+  unlink(sock_path.c_str());
+
+  // Set up a UNIX domain socket
+  stream_protocol::endpoint  ep(sock_path);
+  stream_protocol::socket*   sock_ = new stream_protocol::socket(io_ctx);
+  stream_protocol::acceptor* acc_  = new stream_protocol::acceptor(io_ctx, ep);
+
+  // Move ownership to this->acc
+  std::unique_ptr<stream_protocol::acceptor> acc_ptr(acc_);
+  acc = std::move(acc_ptr);
+
+  // Move ownership to this->sock
+  std::unique_ptr<stream_protocol::socket> sock_ptr(sock_);
+  sock = std::move(sock_ptr);
+
+  // Welcome the first connection
+  accept_conn();
+
+  nas_log->info("Starting the server...\n");
+  start(IFACE_THREAD_PRIO);
+};
+
+void nas_extif_unix::handle_write(void)
+{
+  srslte::byte_buffer_t pdu;
+
+  if (not tx_queue.try_pop(&pdu))
+    return;
+
+  boost::asio::async_write(*sock, boost::asio::buffer(pdu.msg, pdu.N_bytes),
+      [this](boost::system::error_code ec, std::size_t len)
+      {
+        if (!ec) {
+          nas_log->info("Tx %zu bytes to external NAS interface\n", len);
+        } else {
+          nas_log->warning("External NAS write() handler got error (ec=%d)\n", ec.value());
+        }
+
+        // Keep writing unless the queue is empty
+        handle_write();
+      });
+}
+
+void nas_extif_unix::handle_read(void)
+{
+  sock->async_read_some(boost::asio::buffer(buf),
+      [this](boost::system::error_code ec, std::size_t len)
+      {
+        if (!ec) {
+          nas_log->info("Rx %zu bytes from external NAS interface\n", len);
+
+          // Invoke the Rx callback
+          srslte::byte_buffer_t pdu;
+          pdu.append_bytes(buf, len);
+          recv_cb(pdu);
+
+          // Keep reading
+          handle_read();
+        } else {
+          nas_log->info("External NAS interface has lost connection\n");
+          has_connection = false;
+          sock->release();
+        }
+      });
+}
+
+void nas_extif_unix::accept_conn(void)
+{
+  acc->async_accept(
+      [this](boost::system::error_code ec, stream_protocol::socket sock_)
+      {
+        if (!ec) {
+          if (!has_connection) {
+            nas_log->info("Accepted connection on external NAS interface\n");
+            *sock = std::move(sock_);
+            has_connection = true;
+            handle_read();
+          } else {
+            nas_log->warning("NAS interface already has an active connection, rejecting...\n");
+            boost::asio::write(sock_, boost::asio::buffer("REJECT"));
+          }
+        } else {
+          nas_log->warning("External NAS connection handler got error (ec=%d)\n", ec.value());
+        }
+
+        // Keep waiting for a new connection
+        accept_conn();
+      });
+}
+
+void nas_extif_unix::run_thread(void)
+{
+  // This is a blocking call
+  io_ctx.run();
+}
+
+void nas_extif_unix::stop(void)
+{
+  io_ctx.stop();
+  wait_thread_finish();
+}
+
+void nas_extif_unix::close(void)
+{
+  stop();
+}
+
+int nas_extif_unix::write(const srslte::byte_buffer_t& pdu)
+{
+  if (!has_connection) {
+    nas_log->error("External NAS entity is not connected\n");
+    return -EIO;
+  }
+
+  tx_queue.push(pdu);
+  handle_write();
+  return 0;
+}
+
+} // namespace srsue

--- a/srsue/src/stack/upper/rrctl.cc
+++ b/srsue/src/stack/upper/rrctl.cc
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2020 Software Radio Systems Limited
+ * Author: Vadim Yanitskiy <axilirator@gmail.com>
+ * Sponsored by Positive Technologies
+ *
+ * This file is part of srsLTE.
+ *
+ * srsLTE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * srsLTE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * A copy of the GNU Affero General Public License can be found in
+ * the LICENSE file in the top-level directory of this distribution
+ * and at http://www.gnu.org/licenses/.
+ *
+ */
+
+#include <stdint.h>
+#include <arpa/inet.h>
+
+#include "srsue/hdr/stack/upper/rrctl.h"
+
+namespace rrctl {
+
+namespace proto {
+
+std::string msg_hdr_desc(proto::msg_type type, proto::msg_disc disc, uint16_t len)
+{
+  std::string desc;
+
+  switch (type) {
+  case RRCTL_RESET:
+    desc += "Reset";
+    break;
+  case RRCTL_PLMN_SEARCH:
+    desc += "PLMN Search";
+    break;
+  case RRCTL_PLMN_SELECT:
+    desc += "PLMN Select";
+    break;
+  case RRCTL_CONN_ESTABLISH:
+    desc += "Connection Establish";
+    break;
+  case RRCTL_CONN_RELEASE:
+    desc += "Connection Release";
+    break;
+  case RRCTL_DATA:
+    desc += "Data (PDU)";
+    break;
+  default:
+    desc += "<UNKNOWN>";
+  }
+
+  desc += " ";
+
+  switch (disc) {
+  case RRCTL_REQ:
+    desc += "Request";
+    break;
+  case RRCTL_IND:
+    desc += "Indication";
+    break;
+  case RRCTL_CNF:
+    desc += "Confirmation";
+    break;
+  case RRCTL_ERR:
+    desc += "Error";
+    break;
+  }
+
+  if (len > 0) {
+    desc += " (length ";
+    desc += std::to_string(len);
+    desc += ")";
+  }
+
+  return desc;
+}
+
+}
+
+namespace codec {
+
+void enc_hdr(srslte::byte_buffer_t& buf,
+             proto::msg_type type,
+             proto::msg_disc disc,
+             uint16_t len)
+{
+  struct proto::msg_hdr hdr = {
+    .type = (uint8_t) type,
+    .disc = (uint8_t) disc,
+    .len = ntohs(len),
+  };
+
+  buf.append_bytes((const uint8_t*) &hdr, sizeof(hdr));
+}
+
+const uint8_t* dec_hdr(const srslte::byte_buffer_t& buf,
+                       proto::msg_type& type,
+                       proto::msg_disc& disc,
+                       uint16_t& len)
+{
+  const struct proto::msg_hdr* hdr;
+
+  // Make sure at least header is present
+  if (buf.N_bytes < sizeof(*hdr))
+    throw codec::error("header is too short");
+
+  hdr = reinterpret_cast<const struct proto::msg_hdr*> (buf.msg);
+  type = static_cast<proto::msg_type> (hdr->type);
+  disc = static_cast<proto::msg_disc> (hdr->disc);
+  len = htons(hdr->len);
+
+  // Make sure the whole message fits
+  if (buf.N_bytes < sizeof(*hdr) + len)
+    throw codec::error("body is too short");
+
+  // Return pointer to the payload (if present)
+  return len ? hdr->data : NULL;
+}
+
+void enc_plmn_search_res(srslte::byte_buffer_t& buf,
+                         const srsue::rrc_interface_nas::found_plmn_t* plmns,
+                         size_t nof_plmns)
+{
+  struct proto::msg_plmn_search_res msg;
+  uint16_t msg_len;
+
+  if (nof_plmns > 16)
+    throw codec::error("too many PLMNS to encode");
+  msg.nof_plmns = static_cast<uint8_t> (nof_plmns);
+
+  for (size_t i = 0; i < nof_plmns; i++) {
+    std::pair<uint16_t, uint16_t> mcc_mnc = plmns[i].plmn_id.to_number();
+    msg.plmns[i].mcc = htons(mcc_mnc.first);
+    msg.plmns[i].mnc = htons(mcc_mnc.second);
+    msg.plmns[i].tac = htons(plmns[i].tac);
+  }
+
+  msg_len = sizeof(proto::msg_plmn_search_res::plmn) * nof_plmns + 1;
+  enc_hdr(buf, proto::RRCTL_PLMN_SEARCH, proto::RRCTL_CNF, msg_len);
+  buf.append_bytes((uint8_t *) &msg, msg_len);
+}
+
+void dec_plmn_select_req(std::pair<uint16_t, uint16_t>& mcc_mnc,
+                         const uint8_t* payload, size_t len)
+{
+  const struct proto::msg_plmn_select_req* msg;
+
+  if (len < sizeof(*msg))
+    throw codec::error("body is too short");
+
+  msg = reinterpret_cast<const struct proto::msg_plmn_select_req*> (payload);
+  mcc_mnc.first  = htons(msg->mcc);
+  mcc_mnc.second = htons(msg->mnc);
+}
+
+void dec_conn_establish_req(srslte::establishment_cause_t& cause,
+                            const uint8_t*& pdu, size_t& pdu_len,
+                            const uint8_t* payload, size_t len)
+{
+  const struct proto::msg_conn_establish_req* msg;
+
+  if (len < sizeof(*msg))
+    throw codec::error("body is too short");
+
+  msg = reinterpret_cast<const struct proto::msg_conn_establish_req*> (payload);
+  cause = static_cast<srslte::establishment_cause_t> (msg->cause);
+  pdu_len = len - 1;
+  pdu = msg->pdu;
+}
+
+void enc_data_ind(srslte::byte_buffer_t& buf,
+                  const uint8_t *pdu, size_t pdu_len,
+                  uint32_t lcid)
+{
+  struct proto::msg_data msg;
+
+  msg.lcid = htonl(lcid);
+
+  enc_hdr(buf, proto::RRCTL_DATA, proto::RRCTL_IND, sizeof(msg) + pdu_len);
+  buf.append_bytes((const uint8_t*) &msg, sizeof(msg));
+  buf.append_bytes(pdu, pdu_len);
+}
+
+} // namespace codec
+
+} // namespace rrctl

--- a/srsue/test/upper/nas_test.cc
+++ b/srsue/test/upper/nas_test.cc
@@ -227,11 +227,11 @@ int security_command_test()
   usim.init(&args);
 
   {
-    srsue::nas nas(&nas_log, &timers);
     nas_args_t cfg;
     cfg.eia = "1,2,3";
     cfg.eea = "0,1,2,3";
-    nas.init(&usim, &rrc_dummy, &gw, cfg);
+    srsue::nas nas(&nas_log, &timers, cfg);
+    nas.init(&usim, &rrc_dummy, &gw);
     rrc_dummy.init(&nas);
 
     // push auth request PDU to NAS to generate security context
@@ -298,11 +298,11 @@ int mme_attach_request_test()
     nas_args_t nas_cfg;
     nas_cfg.force_imsi_attach = true;
     nas_cfg.apn_name          = "test123";
-    srsue::nas  nas(&nas_log, &timers);
+    srsue::nas  nas(&nas_log, &timers, nas_cfg);
     srsue::gw   gw;
     stack_dummy stack(&pdcp_dummy, &nas);
 
-    nas.init(&usim, &rrc_dummy, &gw, nas_cfg);
+    nas.init(&usim, &rrc_dummy, &gw);
     rrc_dummy.init(&nas);
 
     gw_args_t gw_args;
@@ -381,13 +381,13 @@ int esm_info_request_test()
   pool = byte_buffer_pool::get_instance();
 
   {
-    srsue::nas nas(&nas_log, &timers);
     nas_args_t cfg;
     cfg.apn_name          = "srslte";
     cfg.apn_user          = "srsuser";
     cfg.apn_pass          = "srspass";
     cfg.force_imsi_attach = true;
-    nas.init(&usim, &rrc_dummy, &gw, cfg);
+    srsue::nas nas(&nas_log, &timers, cfg);
+    nas.init(&usim, &rrc_dummy, &gw);
 
     // push ESM info request PDU to NAS to generate response
     unique_byte_buffer_t tmp = srslte::allocate_unique_buffer(*pool, true);
@@ -436,10 +436,10 @@ int dedicated_eps_bearer_test()
 
   srslte::byte_buffer_pool* pool = byte_buffer_pool::get_instance();
 
-  srsue::nas nas(&nas_log, &timers);
   nas_args_t cfg        = {};
   cfg.force_imsi_attach = true; // make sure we get a fresh security context
-  nas.init(&usim, &rrc_dummy, &gw, cfg);
+  srsue::nas nas(&nas_log, &timers, cfg);
+  nas.init(&usim, &rrc_dummy, &gw);
 
   // push dedicated EPS bearer PDU to NAS
   unique_byte_buffer_t tmp = srslte::allocate_unique_buffer(*pool, true);

--- a/srsue/ue.conf.example
+++ b/srsue/ue.conf.example
@@ -165,6 +165,16 @@ imei = 353490069873319
 #eea = 0,1,2
 
 #####################################################################
+# External NAS interface configuration
+#
+# enable:               Disable the built-in NAS implementation, provide external interface
+# sock_path:            UNIX socket path of the external interface
+#####################################################################
+[extnas]
+#enable = false
+#sock_path = /tmp/ue_extnas.sock
+
+#####################################################################
 # GW configuration
 #
 # ip_devname:           Name of the tun_srsue device. Default: tun_srsue


### PR DESCRIPTION
This pull request introduces the external NAS (Non-access stratum) interface, that would allow an external entity to take control over the RRC layer of srsUE using a custom, ad-hoc RRCTL protocol. The interface substitutes the built-in NAS implementation, so it becomes possible to send arbitrary NAS PDUs to the network.

This feature enables security researchers to test LTE networks against various exceptional scenarios. Similar work has been done (read about LTEFuzz for more details) by researchers from Korea Advanced Institute of Science and Technology (KAIST), but unfortunately the source code had never been published.

Please note that I don't have a solid C++ coding experience and this is my first dive into the world of smart / unique pointers, Boost, and threads, so please do not judge strictly.