### PR TITLE
[RFC] Fix some minor compile issues with GCC 10.1

### DIFF
--- a/lib/include/srslte/common/move_callback.h
+++ b/lib/include/srslte/common/move_callback.h
@@ -22,6 +22,9 @@
 #ifndef SRSLTE_MOVE_CALLBACK_H
 #define SRSLTE_MOVE_CALLBACK_H
 
+#include <cstdlib>
+#include <cstdint>
+#include <cstdio>
 #include <cstddef>
 #include <functional>
 #include <type_traits>

--- a/lib/src/phy/fec/viterbi37_avx2.c
+++ b/lib/src/phy/fec/viterbi37_avx2.c
@@ -39,7 +39,7 @@ static union branchtab27 {
   __m256i       v;
 } Branchtab37_sse2[3];
 
-int firstGo;
+extern int firstGo;
 /* State info for instance of Viterbi decoder */
 struct v37 {
   metric_t    metrics1;                  /* path metric buffer 1 */

--- a/lib/src/phy/rf/rf_helper.h
+++ b/lib/src/phy/rf/rf_helper.h
@@ -60,7 +60,7 @@ static inline int parse_string(char* args, const char* config_arg_base, int chan
   int ret = SRSLTE_ERROR;
 
   char  config_key[RF_PARAM_LEN] = {0};
-  char  config_str[RF_PARAM_LEN] = {0};
+  char  config_str[RF_PARAM_LEN-1] = {0};
   char* config_ptr               = NULL;
 
   // try to parse parameter without index as is


### PR DESCRIPTION
GCC 10.1 introduces a few changes that appear to cause minor breakage to existing projects. Nothing too major, but not always immediately obvious from the compiler/linker output.

Three issues encountered when building srsLTE, addressed here:

1. `-fno-common` being enabled by default means that global variables can only be tentatively declared once. If declared without `extern`, then they appear to be multiply declared and compiling fails. [1] Note that srsLTE appears to have two implementations of the relevant code (the edited one below, and the 16 bit AVX2 implementation), so this fix may be a little less straightforward, and this particular definition of `extern int firstGo` may need to go into a header in common by the two implementations [2].

2. Some implicit includes need to be made explicitly now. This looks to be related to [1] where it mentions C++ header dependency issues.

3. A Werror=stringop-truncation warning (treated as error) for strncpy() fails to compile when doing a strncpy from a variable of length X, to a variable of length X, as there is potential on the edge condition to lack space for the tailing null character. In this patch I reduced the permitted length of the incoming parameter, since I imagine 255 vs. 256 character limit will not have any impact.

Refs:

[1] https://gcc.gnu.org/gcc-10/porting_to.html
[2] https://gcc.gnu.org/gcc-10/changes.html
