### PR TITLE
Update proc_ra.cc to bugfix RA-RNTI calculation

### DIFF
--- a/srsue/src/stack/mac/proc_ra.cc
+++ b/srsue/src/stack/mac/proc_ra.cc
@@ -162,7 +162,7 @@ void ra_proc::state_pdcch_setup()
   phy_interface_mac_lte::prach_info_t info = phy_h->prach_get_info();
   if (info.is_transmitted) {
     ra_tti  = info.tti_ra;
-    ra_rnti = 1 + (ra_tti % 10) + info.f_id;
+    ra_rnti = 1 + (ra_tti % 10) + (10 * info.f_id);
     rInfo("seq=%d, ra-rnti=0x%x, ra-tti=%d, f_id=%d\n", sel_preamble, ra_rnti, info.tti_ra, info.f_id);
     log_h->console("Random Access Transmission: seq=%d, ra-rnti=0x%x\n", sel_preamble, ra_rnti);
     rar_window_st   = ra_tti + 3;


### PR DESCRIPTION
Bugfix the wrong ra_rnti calculation in ra_proc::state_pdcch_setup.

According to TS 36.321 Subsection 5.1.4 Random Access Response reception, we can see the formula on RA-RNTI, which is,
    RA-RNTI= 1 + t_id + 10*f_id,
where t_id is the index of the first subframe of the specified PRACH (0≤ t_id <10), and f_id is the index of the specified PRACH within that subframe, in ascending order of frequency domain (0≤ f_id< 6). Then, reading the srslte source code, we can see that, the code should bugfix. 

BTW, the wrong code can run normal for LTE_FDD, causing of the info_f_id = 0; but it should be wrong, when it is LTE_TDD.