### PR TITLE
Fix missing static tag in enb_cfg_parser add_library.

### DIFF
--- a/srsenb/src/CMakeLists.txt
+++ b/srsenb/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if (RPATH)
   SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 endif (RPATH)
 
-add_library(enb_cfg_parser parser.cc enb_cfg_parser.cc)
+add_library(enb_cfg_parser STATIC parser.cc enb_cfg_parser.cc)
 
 add_executable(srsenb main.cc enb.cc metrics_stdout.cc metrics_csv.cc)
 target_link_libraries(srsenb  srsenb_phy


### PR DESCRIPTION
add a missing static tag for the enb_cfg_parser  library.