### PR TITLE
Circuit-switched Fallback eNodeB Stability

### DIFF
--- a/srsenb/sib.conf.example
+++ b/srsenb/sib.conf.example
@@ -137,6 +137,23 @@ sib3 =
     }
 };
 
+#####################################################################
+# sib7 configuration options (See TS 36.331)
+# Contains GERAN neighbor information for CSFB and inter-rat handover.
+# Must be added to sib1::sched_info::si_mapping_info array parameter to be transmitted
+#
+# t_resel_geran: Cell reselection timer (seconds)
+# carrier_freqs_info_list: A list of carrier frequency groups.
+#     cell_resel_prio: Absolute priority of the carrier frequency group
+#     ncc_permitted: 8-bit bitmap of NCC carriers permitted for monitoring
+#     q_rx_lev_min: Minimum receive level in gsm cell, ([field_val] * 2) - 115 = [level in dBm]
+#     thresh_x_high: Srclev threshold (dB) to select to a higher-priority RAT/Frequency
+#     thresh_x_low: Srclev threshold (dB) to select to a lower-priority RAT/Frequency
+#     start_arfcn: Initial search ARFCN value
+#     band_ind: One of "dcs1800" or "pcs1900" Disambiguates ARFCNs in these bands, has no meaning for other ARFCNs.
+#     explicit_list_of_arfcns: List of ARFCN numbers in the group
+#
+#####################################################################
 sib7 =
 {
     t_resel_geran = 1;
@@ -151,6 +168,9 @@ sib7 =
 
             start_arfcn = 871;
             band_ind = "dcs1800";
+            explicit_list_of_arfcns = (
+                871
+            );
         }
     );
 };

--- a/srsenb/src/stack/rrc/rrc.cc
+++ b/srsenb/src/stack/rrc/rrc.cc
@@ -1649,9 +1649,13 @@ void rrc::ue::send_connection_release()
   dl_dcch_msg.msg.c1().rrc_conn_release().crit_exts.c1().rrc_conn_release_r8().release_cause = release_cause_e::other;
   if (is_csfb) {
     rrc_conn_release_r8_ies_s& rel_ies = dl_dcch_msg.msg.c1().rrc_conn_release().crit_exts.c1().rrc_conn_release_r8();
-    rel_ies.redirected_carrier_info_present = true;
-    rel_ies.redirected_carrier_info.set_geran();
-    rel_ies.redirected_carrier_info.geran() = parent->sib7.carrier_freqs_info_list[0].carrier_freqs;
+    if (parent->sib7.carrier_freqs_info_list.size() > 0) {
+      rel_ies.redirected_carrier_info_present = true;
+      rel_ies.redirected_carrier_info.set_geran();
+      rel_ies.redirected_carrier_info.geran() = parent->sib7.carrier_freqs_info_list[0].carrier_freqs;
+    } else {
+      rel_ies.redirected_carrier_info_present = false;
+    }
   }
 
   send_dl_dcch(&dl_dcch_msg);


### PR DESCRIPTION
Hello!

This pull request contains two commits addressing issues I encountered while integrating with a system using circuit-switched fallback. The first commit addresses a crash in the RRC message generation code. If the UE sends a circuit switched fallback context modification request, the eNodeB blindly accessed the first element of an asn1 array, which could actually be empty. This commit adds a check to determine if the array is non-empty before attempting to access the first element.

The second commit adds documentation to the sib conf file describing the parameters for sib7. I spent a while looking at the config parser and mapping the parameters to the 3GPP specs to understand what was going on, and want to save future users the same effort : )

Testing:
* debug and release build on archlinux with gcc/g++ version 10.1.0.
* end-to-end circuit switched fallback with one UE to an osmocom 2G network.
* no crash with CSFB in both the case that sib7:explicit_list_of_arfcns is defined and not defined.

Unrelated:
Thanks for putting together this project and releasing it to the wider community! It has allowed me to stay productive at home with a low-power SDR in unlicensed fequencies while I'm unable to access my university lab's equipment. The maturity and stability of the codebase is admirable!