### PR TITLE
use SoapySDRDevice_enumerateStrArgs to pass device_args

### DIFF
--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -286,7 +286,8 @@ float rf_soapy_get_rssi(void* h)
 int rf_soapy_open_multi(char* args, void** h, uint32_t num_requested_channels)
 {
   size_t          length;
-  SoapySDRKwargs* soapy_args = SoapySDRDevice_enumerate(NULL, &length);
+  printf("using Soapy enumerate device API with device_args=%s\n", args);
+  SoapySDRKwargs* soapy_args = SoapySDRDevice_enumerateStrArgs(args, &length);
 
   if (length == 0) {
     printf("No Soapy devices found.\n");


### PR DESCRIPTION
Hi, 
   In using LimeSDR-USB we have a need to select from a list of available devices. This PR is a simple change to leverage the SoapySDRDevice_enumerateStrArgs API to pass string based args to the SDR driver. Not sure about the original intention to pass NULL for device_args, we hope this can help and does not break anything. The tests we've done are using --rf.device_args to switch between devices of different serial number:
- srsue --rf.device_args=serial=[serial-number-1]
- srsue --rf.device_args=serial=[serial-number-2]

And two applications can be run simultaneously using two different LimeSDR connected to the same host. 

