### PR TITLE
eNB: add parameter gtp_ext_addr

### DIFF
--- a/lib/include/srslte/interfaces/enb_interfaces.h
+++ b/lib/include/srslte/interfaces/enb_interfaces.h
@@ -524,6 +524,7 @@ typedef struct {
   uint16_t    mnc;     // BCD-coded with 0xF filler
   std::string mme_addr;
   std::string gtp_bind_addr;
+  std::string gtp_ext_addr;
   std::string s1c_bind_addr;
   std::string enb_name;
 } s1ap_args_t;

--- a/srsenb/enb.conf.example
+++ b/srsenb/enb.conf.example
@@ -10,6 +10,7 @@
 # mnc:            Mobile Network Code
 # mme_addr:       IP address of MME for S1 connnection
 # gtp_bind_addr:  Local IP address to bind for GTP connection
+# gtp_ext_addr:   External gateway IP address for GTP (optional, defaults to gtp_bind_addr)
 # s1c_bind_addr:  Local IP address to bind for S1AP connection
 # n_prb:          Number of Physical Resource Blocks (6,15,25,50,75,100)
 # tm:             Transmission mode 1-4 (TM1 default)

--- a/srsenb/src/main.cc
+++ b/srsenb/src/main.cc
@@ -72,6 +72,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     ("enb.mnc",           bpo::value<string>(&mnc)->default_value("01"),                           "Mobile Network Code")
     ("enb.mme_addr",      bpo::value<string>(&args->stack.s1ap.mme_addr)->default_value("127.0.0.1"),"IP address of MME for S1 connection")
     ("enb.gtp_bind_addr", bpo::value<string>(&args->stack.s1ap.gtp_bind_addr)->default_value("192.168.3.1"), "Local IP address to bind for GTP connection")
+    ("enb.gtp_ext_addr",  bpo::value<string>(&args->stack.s1ap.gtp_ext_addr)->default_value(""), "GTP external address (gateway), defaults to gtp_bind_addr")
     ("enb.s1c_bind_addr", bpo::value<string>(&args->stack.s1ap.s1c_bind_addr)->default_value("192.168.3.1"), "Local IP address to bind for S1AP connection")
     ("enb.n_prb",         bpo::value<uint32_t>(&args->enb.n_prb)->default_value(25),               "Number of PRB")
     ("enb.nof_ports",     bpo::value<uint32_t>(&args->enb.nof_ports)->default_value(1),            "Number of ports")
@@ -287,6 +288,11 @@ void parse_args(all_args_t* args, int argc, char* argv[])
   if (pos != enb_id.size()) {
     cout << "Error parsing enb.enb_id: " << enb_id << "." << endl;
     exit(1);
+  }
+
+  // gtp_ext_addr is optional, defaults to gtp_bind_addr
+  if (args->stack.s1ap.gtp_ext_addr == "") {
+    args->stack.s1ap.gtp_ext_addr = args->stack.s1ap.gtp_bind_addr;
   }
 
   // Apply all_level to any unset layers

--- a/srsenb/src/stack/upper/s1ap.cc
+++ b/srsenb/src/stack/upper/s1ap.cc
@@ -911,7 +911,7 @@ bool s1ap::ue::send_initial_ctxt_setup_response(const asn1::s1ap::init_context_s
     auto& item = container.erab_setup_list_ctxt_su_res.value[i].value.erab_setup_item_ctxt_su_res();
     item.transport_layer_address.resize(32);
     uint8_t addr[4];
-    inet_pton(AF_INET, s1ap_ptr->args.gtp_bind_addr.c_str(), addr);
+    inet_pton(AF_INET, s1ap_ptr->args.gtp_ext_addr.c_str(), addr);
     for (uint32_t j = 0; j < 4; ++j) {
       item.transport_layer_address.data()[j] = addr[3 - j];
     }
@@ -932,13 +932,18 @@ bool s1ap::ue::send_erab_setup_response(const erab_setup_resp_s& res_)
 
   res = res_;
 
-  // Fill in the GTP bind address for all bearers
+  // if no external GTP address given, default to GTP bind addr
+  if (s1ap_ptr->args.gtp_ext_addr == "") {
+    s1ap_ptr->args.gtp_ext_addr = s1ap_ptr->args.gtp_bind_addr;
+  }
+
+  // Fill in the GTP address for all bearers
   if (res.protocol_ies.erab_setup_list_bearer_su_res_present) {
     for (uint32_t i = 0; i < res.protocol_ies.erab_setup_list_bearer_su_res.value.size(); ++i) {
       auto& item = res.protocol_ies.erab_setup_list_bearer_su_res.value[i].value.erab_setup_item_bearer_su_res();
       item.transport_layer_address.resize(32);
       uint8_t addr[4];
-      inet_pton(AF_INET, s1ap_ptr->args.gtp_bind_addr.c_str(), addr);
+      inet_pton(AF_INET, s1ap_ptr->args.gtp_ext_addr.c_str(), addr);
       for (uint32_t j = 0; j < 4; ++j) {
         item.transport_layer_address.data()[j] = addr[3 - j];
       }


### PR DESCRIPTION
If the eNodeB is behind some gateway, the initial_ctxt_setup_response needs to contain that gateway address rather than the (unreachable) bind address. If unset, the parameter defaults to the bind address.