### PR TITLE
retry soapy set srate if failure for both tx and rx chain

### DIFF
--- a/lib/src/phy/rf/rf_soapy_imp.c
+++ b/lib/src/phy/rf/rf_soapy_imp.c
@@ -38,6 +38,7 @@
 #define HAVE_ASYNC_THREAD 0
 
 #define STOP_STREAM_BEFORE_RATE_CHANGE 0
+#define SET_SAMPLING_RATE_RETRY 3
 #define USE_TX_MTU 0
 #define SET_RF_BW 0
 
@@ -604,8 +605,14 @@ double rf_soapy_set_rx_srate(void* h, double rate)
 #endif // STOP_STREAM_BEFORE_RATE_CHANGE
 
   for (uint32_t i = 0; i < handler->num_rx_channels; i++) {
-    if (SoapySDRDevice_setSampleRate(handler->device, SOAPY_SDR_RX, i, rate) != 0) {
+    int retry_counter = 0;
+    while (SoapySDRDevice_setSampleRate(handler->device, SOAPY_SDR_RX, i, rate) != 0) {
       printf("setSampleRate Rx fail: %s\n", SoapySDRDevice_lastError());
+      retry_counter ++;
+      printf("retrying %d/%d...\n", retry_counter, SET_SAMPLING_RATE_RETRY);
+      usleep(1000000);
+      if(retry_counter <= SET_SAMPLING_RATE_RETRY)
+        continue;
       return SRSLTE_ERROR;
     }
 
@@ -649,8 +656,14 @@ double rf_soapy_set_tx_srate(void* h, double rate)
 #endif // STOP_STREAM_BEFORE_RATE_CHANGE
 
   for (uint32_t i = 0; i < handler->num_tx_channels; i++) {
-    if (SoapySDRDevice_setSampleRate(handler->device, SOAPY_SDR_TX, i, rate) != 0) {
+    int retry_counter = 0;
+    while (SoapySDRDevice_setSampleRate(handler->device, SOAPY_SDR_TX, i, rate) != 0) {
       printf("setSampleRate Tx fail: %s\n", SoapySDRDevice_lastError());
+      retry_counter ++;
+      printf("retrying %d/%d...\n", retry_counter, SET_SAMPLING_RATE_RETRY);
+      usleep(1000000);
+      if(retry_counter <= SET_SAMPLING_RATE_RETRY)
+        continue;
       return SRSLTE_ERROR;
     }
 


### PR DESCRIPTION
Hi, 
   We noticed the failure to set sampling rate, related to the issue discussion here: https://github.com/srsLTE/srsLTE/issues/562

The problem exists for both USB 2.0 and USB 3.0 connection. While tracing the code, I noticed the earlier attempts of setting sampling rate when through without a problem but later attempts would fail consistently. I wonder if this is limesdr specific issue (time it takes to perform srate setting?) and was hoping perhaps people from myriadrf @gracid can comment on it? Current workaround is to have a simple retry logic. 

NOTE: I also wonder whether it's because the streaming needs to be stopped before changing sampling rate. But enabling that part of the code (#define STOP_STREAM_BEFORE_RATE_CHANGE 1) does not seem to matter. 



```
[INFO] Make connection: 'LimeSDR-USB [USB 3.0] 9072C00D7311E'
[INFO] Reference clock 30.72 MHz
[INFO] Device name: LimeSDR-USB
[INFO] Reference: 30.72 MHz
[INFO] LMS7002M register cache: Disabled
[INFO] RX LPF configured
[INFO] Filter calibrated. Filter order-4th, filter bandwidth set to 5 MHz.Real pole 1st order filter set to 2.5 MHz. Preemphasis filter not active
[INFO] TX LPF configured
[ERROR] TuneVCO(CGEN) - failed to lock (cmphl!=3)
[ERROR] SetFrequencyCGEN(491.52 MHz) failed
Soapy has found device #0: addr=1d50:6108, driver=lime, label=LimeSDR-USB [USB 3.0] 9072C00D7311E, media=USB 3.0, module=FX3, name=LimeSDR-USB, serial=0009072C00D7311E, 
Selecting Soapy device: 0
Setting up Rx stream with 1 channel(s)
Setting up Tx stream with 1 channel(s)
Available device sensors: 
 - clock_locked
 - lms7_temp
Available sensors for Rx channel 0: 
 - lo_locked
State of gain elements for Rx channel 0 (AGC not supported):
 - TIA: 9.00 dB
 - LNA: 30.00 dB
 - PGA: -7.00 dB
State of gain elements for Tx channel 0 (AGC not supported):
 - PAD: 0.00 dB
 - IAMP: 0.00 dB
Rx antenna set to LNAL
Tx antenna set to BAND1

==== eNodeB started ===
Type <t> to view trace
Closing stdin thread.
[INFO] RX LPF configured
[ERROR] setSampleRate(Rx, 0, 7.68 MHz) Failed
[INFO] Filter calibrated. Filter order-4th, filter bandwidth set to 7.68 MHz.Real pole 1st order filter set to 2.5 MHz. Preemphasis filter not active
[INFO] TX LPF configured
setSampleRate Rx fail: SoapyLMS7::setSampleRate() failed
```

