### PR TITLE
Fixes for examples - Cell search and PSSCH_UE

### DIFF
--- a/lib/examples/cell_search.c
+++ b/lib/examples/cell_search.c
@@ -65,11 +65,13 @@ struct cells results[1024];
 
 float rf_gain = 70.0;
 char* rf_args = "";
+char* rf_dev = "";
 
 void usage(char* prog)
 {
   printf("Usage: %s [agsendtvb] -b band\n", prog);
   printf("\t-a RF args [Default %s]\n", rf_args);
+  printf("\t-d RF devicename [Default %s]\n", rf_dev);
   printf("\t-g RF gain [Default %.2f dB]\n", rf_gain);
   printf("\t-s earfcn_start [Default All]\n");
   printf("\t-e earfcn_end [Default All]\n");
@@ -87,6 +89,9 @@ void parse_args(int argc, char** argv)
         break;
       case 'b':
         band = (int)strtol(argv[optind], NULL, 10);
+        break;
+      case 'd':
+        rf_dev = argv[optind];
         break;
       case 's':
         earfcn_start = (int)strtol(argv[optind], NULL, 10);
@@ -151,7 +156,7 @@ int main(int argc, char** argv)
   parse_args(argc, argv);
 
   printf("Opening RF device...\n");
-  if (srslte_rf_open(&rf, rf_args)) {
+  if (srslte_rf_open_devname(&rf, rf_dev, rf_args, 1)) {
     ERROR("Error opening rf\n");
     exit(-1);
   }

--- a/lib/examples/pssch_ue.c
+++ b/lib/examples/pssch_ue.c
@@ -253,7 +253,7 @@ int main(int argc, char** argv)
   if (!prog_args.input_file_name) {
     printf("Opening RF device...\n");
 
-    if (srslte_rf_open_multi(&radio, prog_args.rf_args, prog_args.nof_rx_antennas)) {
+    if (srslte_rf_open_devname(&radio, prog_args.rf_dev, prog_args.rf_args, prog_args.nof_rx_antennas)) {
       ERROR("Error opening rf\n");
       exit(-1);
     }


### PR DESCRIPTION
The following commits address the following points

- In PSSCH UE example, the RF device argument passed from cmdline was ignored
- In Cell search example, there was no option to specify the RF device to use (multiple SDRs usecase or usecase with multiple SDR driver (SoapySDR vs Native Lime API) for same SDR)