### PR TITLE
srsenb: Handle E-RABReleaseCommand - MME Initiated

### DIFF
--- a/lib/include/srslte/interfaces/enb_interfaces.h
+++ b/lib/include/srslte/interfaces/enb_interfaces.h
@@ -424,6 +424,7 @@ public:
   virtual bool modify_ue_ctxt(uint16_t rnti, const asn1::s1ap::ue_context_mod_request_s& msg)    = 0;
   virtual bool setup_ue_erabs(uint16_t rnti, const asn1::s1ap::erab_setup_request_s& msg)        = 0;
   virtual bool release_erabs(uint32_t rnti)                                                      = 0;
+  virtual bool release_erabs(uint32_t rnti, const asn1::s1ap::erab_release_cmd_s& msg)           = 0;
   virtual void add_paging_id(uint32_t ueid, const asn1::s1ap::ue_paging_id_c& ue_paging_id)      = 0;
 
   /**
@@ -482,6 +483,7 @@ public:
   virtual bool user_release(uint16_t rnti, asn1::s1ap::cause_radio_network_e cause_radio)              = 0;
   virtual void ue_ctxt_setup_complete(uint16_t rnti, const asn1::s1ap::init_context_setup_resp_s& res) = 0;
   virtual void ue_erab_setup_complete(uint16_t rnti, const asn1::s1ap::erab_setup_resp_s& res)         = 0;
+  virtual void ue_erab_release_complete(uint16_t rnti, const asn1::s1ap::erab_release_resp_s& res)     = 0;
   virtual bool is_mme_connected()                                                                      = 0;
 
   /**

--- a/srsenb/hdr/stack/rrc/rrc.h
+++ b/srsenb/hdr/stack/rrc/rrc.h
@@ -86,6 +86,7 @@ public:
   bool modify_ue_ctxt(uint16_t rnti, const asn1::s1ap::ue_context_mod_request_s& msg) override;
   bool setup_ue_erabs(uint16_t rnti, const asn1::s1ap::erab_setup_request_s& msg) override;
   bool release_erabs(uint32_t rnti) override;
+  bool release_erabs(uint32_t rnti, const asn1::s1ap::erab_release_cmd_s& msg) override;
   void add_paging_id(uint32_t ueid, const asn1::s1ap::ue_paging_id_c& UEPagingID) override;
   void ho_preparation_complete(uint16_t rnti, bool is_success, srslte::unique_byte_buffer_t rrc_container) override;
   uint16_t

--- a/srsenb/hdr/stack/rrc/rrc_bearer_cfg.h
+++ b/srsenb/hdr/stack/rrc/rrc_bearer_cfg.h
@@ -85,6 +85,7 @@ public:
 
   // Methods to apply bearer updates
   void add_gtpu_bearer(gtpu_interface_rrc* gtpu, uint32_t erab_id);
+  void rem_gtpu_bearer(srsenb::gtpu_interface_rrc* gtpu, uint32_t erab_id);
   void fill_pending_nas_info(asn1::rrc::rrc_conn_recfg_r8_ies_s* msg);
 
   const std::map<uint8_t, erab_t>&                get_erabs() const { return erabs; }

--- a/srsenb/hdr/stack/rrc/rrc_ue.h
+++ b/srsenb/hdr/stack/rrc/rrc_ue.h
@@ -55,6 +55,7 @@ public:
   void send_connection_reest_rej();
   void send_connection_reconf(srslte::unique_byte_buffer_t sdu);
   void send_connection_reconf_new_bearer();
+  void send_connection_reconf_rem_bearer(const asn1::unbounded_octstring<true>* nas_pdu);
   void send_connection_reconf_upd(srslte::unique_byte_buffer_t pdu);
   void send_security_mode_command();
   void send_ue_cap_enquiry();
@@ -76,7 +77,7 @@ public:
 
   bool setup_erabs(const asn1::s1ap::erab_to_be_setup_list_ctxt_su_req_l& e);
   bool setup_erabs(const asn1::s1ap::erab_to_be_setup_list_bearer_su_req_l& e);
-  bool release_erabs(const asn1::s1ap::erab_list_l& e);
+  bool release_erabs(const asn1::s1ap::erab_release_cmd_s& msg);
   bool release_erabs();
 
   // handover

--- a/srsenb/hdr/stack/rrc/rrc_ue.h
+++ b/srsenb/hdr/stack/rrc/rrc_ue.h
@@ -76,6 +76,7 @@ public:
 
   bool setup_erabs(const asn1::s1ap::erab_to_be_setup_list_ctxt_su_req_l& e);
   bool setup_erabs(const asn1::s1ap::erab_to_be_setup_list_bearer_su_req_l& e);
+  bool release_erabs(const asn1::s1ap::erab_list_l& e);
   bool release_erabs();
 
   // handover

--- a/srsenb/hdr/stack/upper/s1ap.h
+++ b/srsenb/hdr/stack/upper/s1ap.h
@@ -75,6 +75,7 @@ public:
   bool user_release(uint16_t rnti, asn1::s1ap::cause_radio_network_e cause_radio) override;
   void ue_ctxt_setup_complete(uint16_t rnti, const asn1::s1ap::init_context_setup_resp_s& res) override;
   void ue_erab_setup_complete(uint16_t rnti, const asn1::s1ap::erab_setup_resp_s& res) override;
+  void ue_erab_release_complete(uint16_t rnti, const asn1::s1ap::erab_release_resp_s& res) override;
   bool is_mme_connected() override;
   bool send_ho_required(uint16_t                     rnti,
                         uint32_t                     target_eci,
@@ -146,6 +147,7 @@ private:
   bool handle_uectxtreleasecommand(const asn1::s1ap::ue_context_release_cmd_s& msg);
   bool handle_s1setupfailure(const asn1::s1ap::s1_setup_fail_s& msg);
   bool handle_erabsetuprequest(const asn1::s1ap::erab_setup_request_s& msg);
+  bool handle_erab_release_cmd(const asn1::s1ap::erab_release_cmd_s& msg);
   bool handle_uecontextmodifyrequest(const asn1::s1ap::ue_context_mod_request_s& msg);
 
   // bool send_ue_capabilities(uint16_t rnti, LIBLTE_RRC_UE_EUTRA_CAPABILITY_STRUCT *caps)
@@ -197,6 +199,7 @@ private:
     bool send_initial_ctxt_setup_response(const asn1::s1ap::init_context_setup_resp_s& res_);
     bool send_initial_ctxt_setup_failure();
     bool send_erab_setup_response(const asn1::s1ap::erab_setup_resp_s& res_);
+    bool send_erab_release_response(const asn1::s1ap::erab_release_resp_s& res_);
     bool was_uectxtrelease_requested() const { return release_requested; }
 
     ue_ctxt_t ctxt      = {};

--- a/srsenb/src/stack/rrc/rrc.cc
+++ b/srsenb/src/stack/rrc/rrc.cc
@@ -316,6 +316,19 @@ bool rrc::release_erabs(uint32_t rnti)
   return ret;
 }
 
+bool rrc::release_erabs(uint32_t rnti, const asn1::s1ap::erab_release_cmd_s& msg)
+{
+  rrc_log->info("Releasing E-RABs for 0x%x\n", rnti);
+  auto user_it = users.find(rnti);
+
+  if (user_it == users.end()) {
+    rrc_log->warning("Unrecognised rnti: 0x%x\n", rnti);
+    return false;
+  }
+
+  return user_it->second->release_erabs(msg.protocol_ies.erab_to_be_released_list.value);
+}
+
 /*******************************************************************************
   Paging functions
   These functions use a different mutex because access different shared variables

--- a/srsenb/src/stack/rrc/rrc.cc
+++ b/srsenb/src/stack/rrc/rrc.cc
@@ -326,7 +326,7 @@ bool rrc::release_erabs(uint32_t rnti, const asn1::s1ap::erab_release_cmd_s& msg
     return false;
   }
 
-  return user_it->second->release_erabs(msg.protocol_ies.erab_to_be_released_list.value);
+  return user_it->second->release_erabs(msg);
 }
 
 /*******************************************************************************

--- a/srsenb/src/stack/rrc/rrc_bearer_cfg.cc
+++ b/srsenb/src/stack/rrc/rrc_bearer_cfg.cc
@@ -350,6 +350,17 @@ void bearer_cfg_handler::add_gtpu_bearer(srsenb::gtpu_interface_rrc* gtpu, uint3
   }
 }
 
+void bearer_cfg_handler::rem_gtpu_bearer(srsenb::gtpu_interface_rrc* gtpu, uint32_t erab_id)
+{
+  auto it = erabs.find(erab_id);
+  if (it != erabs.end()) {
+    // Map e.g. E-RAB 5 to LCID 3 (==DRB1)
+    gtpu->rem_bearer(rnti, erab_id - 2);
+  } else {
+    log_h->error("Removing erab_id=%d to GTPU\n", erab_id);
+  }
+}
+
 void bearer_cfg_handler::fill_pending_nas_info(asn1::rrc::rrc_conn_recfg_r8_ies_s* msg)
 {
   // Add space for NAS messages

--- a/srsenb/src/stack/upper/s1ap.cc
+++ b/srsenb/src/stack/upper/s1ap.cc
@@ -729,7 +729,7 @@ bool s1ap::handle_erab_release_cmd(const erab_release_cmd_s& msg)
   if (u == nullptr) {
     return false;
   }
-
+  
   if (msg.protocol_ies.nas_pdu_present) {
     srslte::unique_byte_buffer_t pdu = srslte::allocate_unique_buffer(*pool);
     if (pdu == nullptr) {

--- a/srsenb/src/stack/upper/s1ap.cc
+++ b/srsenb/src/stack/upper/s1ap.cc
@@ -729,17 +729,6 @@ bool s1ap::handle_erab_release_cmd(const erab_release_cmd_s& msg)
   if (u == nullptr) {
     return false;
   }
-  
-  if (msg.protocol_ies.nas_pdu_present) {
-    srslte::unique_byte_buffer_t pdu = srslte::allocate_unique_buffer(*pool);
-    if (pdu == nullptr) {
-      s1ap_log->error("Fatal Error: Couldn't allocate buffer in s1ap::run_thread().\n");
-      return false;
-    }
-    memcpy(pdu->msg, msg.protocol_ies.nas_pdu.value.data(), msg.protocol_ies.nas_pdu.value.size());
-    pdu->N_bytes = msg.protocol_ies.nas_pdu.value.size();
-    rrc->write_dl_info(u->ctxt.rnti, std::move(pdu));
-  }
 
   // Release E-RABs
   return rrc->release_erabs(u->ctxt.rnti, msg);

--- a/srsenb/test/common/dummy_classes.h
+++ b/srsenb/test/common/dummy_classes.h
@@ -94,6 +94,7 @@ public:
   bool user_release(uint16_t rnti, asn1::s1ap::cause_radio_network_e cause_radio) override { return true; }
   void ue_ctxt_setup_complete(uint16_t rnti, const asn1::s1ap::init_context_setup_resp_s& res) override {}
   void ue_erab_setup_complete(uint16_t rnti, const asn1::s1ap::erab_setup_resp_s& res) override {}
+  void ue_erab_release_complete(uint16_t rnti, const asn1::s1ap::erab_release_resp_s& res) override {}
   bool is_mme_connected() override { return true; }
   bool send_ho_required(uint16_t                     rnti,
                         uint32_t                     target_eci,


### PR DESCRIPTION
The E-RAB RELEASE COMMAND message shall contain the information required by the eNB
to release at least one E-RAB in the E-RAB To Be Released List IE.
If a NAS-PDU IE is contained in the message, the eNB shall pass it to the UE.

Upon reception of the E-RAB RELEASE COMMAND message the eNB shall execute the
release of the requested E-RABs i.e. release of Data Radio Bearer + resources on Uu interface + S1 resource.

The eNB shall report to the MME, in the E-RAB RELEASE RESPONSE message,
the result for all the E-RABs to be released.
- A list of E-RABs which are released successfully
- A list of E-RABs which failed to be released

If the eNB receives an E-RAB RELEASE COMMAND message containing some E-RAB ID IEs that eNB does not recognize,
the eNB shall report the corresponding invalid E-RABs as failed in the E-RAB RELEASE RESPONSE message
with the appropriate cause, e.g., “Unknown E-RAB ID”