### PR TITLE
Improve GNSS Sync

### DIFF
--- a/lib/src/phy/ue/ue_sync.c
+++ b/lib/src/phy/ue/ue_sync.c
@@ -940,31 +940,46 @@ int srslte_ue_sync_run_find_gnss_mode(srslte_ue_sync_t* q,
   INFO("Calibration samples received start at %ld + %f\n", q->last_timestamp.full_secs, q->last_timestamp.frac_secs);
 
   // round to nearest second
-  srslte_timestamp_t ts_next_rx;
+  srslte_timestamp_t ts_next_rx, ts_next_rx_tmp, ts_tmp;
   srslte_timestamp_copy(&ts_next_rx, &q->last_timestamp);
   ts_next_rx.full_secs++;
   ts_next_rx.frac_secs = 0.0;
 
-  INFO("Next desired recv at %ld + %f\n", ts_next_rx.full_secs, ts_next_rx.frac_secs);
+  srslte_timestamp_copy(&ts_next_rx_tmp, &ts_next_rx);
+  
+  INFO("Next desired recv at %ld + %f\n", ts_next_rx_tmp.full, ts_next_rx_tmp.frac_secs);
 
   // get difference in time between second rx and now
-  srslte_timestamp_sub(&ts_next_rx, q->last_timestamp.full_secs, q->last_timestamp.frac_secs);
-  srslte_timestamp_sub(&ts_next_rx, 0, 0.001); ///< account for samples that have already been rx'ed
+  srslte_timestamp_sub(&ts_next_rx_tmp, q->last_timestamp.full_secs, q->last_timestamp.frac_secs);
+  srslte_timestamp_sub(&ts_next_rx_tmp, 0, 0.001); ///< account for samples that have already been rx'ed
 
-  uint64_t align_len = srslte_timestamp_uint64(&ts_next_rx, q->sf_len * 1000);
+  uint64_t align_len = srslte_timestamp_uint64(&ts_next_rx_tmp, q->sf_len * 1000);
 
   DEBUG("Difference between first recv is %ld + %f, realigning %" PRIu64 " samples\n",
-        ts_next_rx.full_secs,
-        ts_next_rx.frac_secs,
+        ts_next_rx_tmp.full_secs,
+        ts_next_rx_tmp.frac_secs,
         align_len);
 
   // receive align_len samples into dummy_buffer, make sure to not exceed buffer len
   uint32_t sample_count = 0;
-  while (sample_count < align_len) {
-    uint32_t actual_rx_len = SRSLTE_MIN(align_len, DUMMY_BUFFER_NUM_SAMPLES);
-    actual_rx_len          = SRSLTE_MIN(align_len - sample_count, actual_rx_len);
+  while (align_len > q->sf_len) {
+    uint32_t actual_rx_len = SRSLTE_MIN(align_len, q->sf_len);
+    actual_rx_len          = SRSLTE_MIN(align_len, actual_rx_len);
     q->recv_callback(q->stream, dummy_offset_buffer, actual_rx_len, &q->last_timestamp);
-    sample_count += actual_rx_len;
+
+    srslte_timestamp_copy(&ts_tmp, &ts_next_rx);
+    srslte_timestamp_sub(&ts_tmp, q->last_timestamp.full_secs, q->last_timestamp.frac_secs);
+    srslte_timestamp_sub(&ts_tmp, 0, 0.001); ///< account for samples that have already been rx'ed
+    align_len = srslte_timestamp_uint64(&ts_tmp, q->sf_len * 1000);
+
+    if (align_len > q->sf_len * 1000) {
+      ts_next_rx.full_secs++;
+      ts_next_rx.frac_secs = 0.0;
+      srslte_timestamp_copy(&ts_tmp, &ts_next_rx);
+      srslte_timestamp_sub(&ts_tmp, q->last_timestamp.full_secs, q->last_timestamp.frac_secs);
+      srslte_timestamp_sub(&ts_tmp, 0, 0.001); ///< account for samples that have already been rx'ed
+      align_len = srslte_timestamp_uint64(&ts_tmp, q->sf_len * 1000);
+    }
   }
 
   DEBUG("Received %d samples during alignment\n", sample_count);

--- a/lib/src/phy/ue/ue_sync.c
+++ b/lib/src/phy/ue/ue_sync.c
@@ -947,7 +947,7 @@ int srslte_ue_sync_run_find_gnss_mode(srslte_ue_sync_t* q,
 
   srslte_timestamp_copy(&ts_next_rx_tmp, &ts_next_rx);
   
-  INFO("Next desired recv at %ld + %f\n", ts_next_rx_tmp.full, ts_next_rx_tmp.frac_secs);
+  INFO("Next desired recv at %ld + %f\n", ts_next_rx_tmp.full_secs, ts_next_rx_tmp.frac_secs);
 
   // get difference in time between second rx and now
   srslte_timestamp_sub(&ts_next_rx_tmp, q->last_timestamp.full_secs, q->last_timestamp.frac_secs);


### PR DESCRIPTION
Added loop to check for GNSS alignment while syncing.
If the received GNSS signal is weak, synchronization errors might occur while syncing.