### PR TITLE
Avoid bounded_bitset constructor with size arg as compiler flags buff…

### DIFF
--- a/srsenb/src/stack/mac/scheduler_grid.cc
+++ b/srsenb/src/stack/mac/scheduler_grid.cc
@@ -482,7 +482,8 @@ alloc_outcome_t sf_grid_t::alloc_ul_data(sched_ue* user, prb_interval alloc, boo
     return alloc_outcome_t::ERROR;
   }
 
-  prbmask_t newmask(ul_mask.size());
+  prbmask_t newmask;
+  newmask.resize(ul_mask.size());
   newmask.fill(alloc.start(), alloc.stop());
   if ((ul_mask & newmask).any()) {
     return alloc_outcome_t::RB_COLLISION;


### PR DESCRIPTION
…er use uninitialized when optimized.

/root/srsLTE/lib/include/srslte/adt/bounded_bitset.h: In member function 'srsenb::alloc_outcome_t srsenb::sf_grid_t::alloc_ul_data(srsenb::sched_ue*, srsenb::prb_interval, bool)':
/root/srsLTE/lib/include/srslte/adt/bounded_bitset.h:219:32: error: 'newmask.srslte::bounded_bitset<100, true>::buffer[<unknown>]' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  219 |       buffer[i] &= other.buffer[i];
      |                    ~~~~~~~~~~~~^