### PR TITLE
srsUE: Add option to filter N_id_2 / PSS to configuration

### DIFF
--- a/lib/include/srslte/interfaces/ue_interfaces.h
+++ b/lib/include/srslte/interfaces/ue_interfaces.h
@@ -491,6 +491,8 @@ typedef struct {
   std::vector<uint32_t> dl_earfcn_list = {3400}; // vectorized version of dl_earfcn that gets populated during init
   std::map<uint32_t, uint32_t> ul_earfcn_map;    // Map linking DL EARFCN and UL EARFCN
 
+  int force_N_id_2 = -1; // Cell identity within the identity group (PSS) to filter.
+
   float dl_freq = -1.0f;
   float ul_freq = -1.0f;
 

--- a/srsue/hdr/phy/search.h
+++ b/srsue/hdr/phy/search.h
@@ -44,7 +44,7 @@ public:
   typedef enum { CELL_NOT_FOUND, CELL_FOUND, ERROR, TIMEOUT } ret_code;
 
   ~search();
-  void     init(srslte::rf_buffer_t& buffer_, srslte::log* log_h, uint32_t nof_rx_channels, search_callback* parent);
+  void     init(srslte::rf_buffer_t& buffer_, srslte::log* log_h, uint32_t nof_rx_channels, search_callback* parent, int force_N_id_2_);
   void     reset();
   float    get_last_cfo();
   void     set_agc_enable(bool enable);

--- a/srsue/src/main.cc
+++ b/srsue/src/main.cc
@@ -391,6 +391,10 @@ static int parse_args(all_args_t* args, int argc, char* argv[])
      bpo::value<uint32_t>(&args->phy.nof_out_of_sync_events)->default_value(20),
      "Number of PHY out-sync events before sending an out-sync event to RRC")
 
+    ("phy.force_N_id_2",
+     bpo::value<int>(&args->phy.force_N_id_2)->default_value(-1),
+     "Force using a specific PSS (set to -1 to allow all PSSs).")
+
     // UE simulation args
     ("sim.airplane_t_on_ms",
      bpo::value<int>(&args->stack.nas.sim.airplane_t_on_ms)->default_value(-1),

--- a/srsue/src/phy/search.cc
+++ b/srsue/src/phy/search.cc
@@ -54,7 +54,7 @@ search::~search()
   srslte_ue_cellsearch_free(&cs);
 }
 
-void search::init(srslte::rf_buffer_t& buffer_, srslte::log* log_h_, uint32_t nof_rx_channels, search_callback* parent)
+void search::init(srslte::rf_buffer_t& buffer_, srslte::log* log_h_, uint32_t nof_rx_channels, search_callback* parent, int force_N_id_2_)
 {
   log_h = log_h_;
   p     = parent;
@@ -73,7 +73,7 @@ void search::init(srslte::rf_buffer_t& buffer_, srslte::log* log_h_, uint32_t no
   // Set options defined in expert section
   p->set_ue_sync_opts(&cs.ue_sync, 0);
 
-  force_N_id_2 = -1;
+  force_N_id_2 = force_N_id_2_;
 }
 
 void search::reset()

--- a/srsue/src/phy/sync.cc
+++ b/srsue/src/phy/sync.cc
@@ -92,7 +92,7 @@ void sync::init(srslte::radio_interface_phy* _radio,
   worker_com->set_nof_workers(nof_workers);
 
   // Initialize cell searcher
-  search_p.init(sf_buffer, log_h, nof_rf_channels, this);
+  search_p.init(sf_buffer, log_h, nof_rf_channels, this, worker_com->args->force_N_id_2);
 
   // Initialize SFN synchronizer, it uses only pcell buffer
   sfn_p.init(&ue_sync, worker_com->args, sf_buffer, sf_buffer.size(), log_h);


### PR DESCRIPTION
Hey!
This change will allow forcing the srsUE to select a specific PSS.
Since I am pretty new to this project and I am not a great C++ developer, I would appreciate if you will look closely to make sure I didn't miss anything.
I compiled it and tested it manually (and I ran the existing tests). I found it quite difficult to test this specific feature using the current tests, so any help on that (unless you are fine with merging it without specific tests) would be appreciated.

Thanks for dedicating time!