### PR TITLE
NAS: Add configuration for full and short network names.

### DIFF
--- a/srsepc/hdr/mme/nas.h
+++ b/srsepc/hdr/mme/nas.h
@@ -136,6 +136,8 @@ typedef struct {
   uint16_t                            paging_timer;
   std::string                         apn;
   std::string                         dns;
+  std::string                         full_net_name;
+  std::string                         short_net_name;
   srslte::CIPHERING_ALGORITHM_ID_ENUM cipher_algo;
   srslte::INTEGRITY_ALGORITHM_ID_ENUM integ_algo;
 } nas_init_t;
@@ -281,6 +283,8 @@ private:
   uint16_t    m_tac       = 0;
   std::string m_apn;
   std::string m_dns;
+  std::string m_full_net_name;
+  std::string m_short_net_name;
 
   // Timers timeout values
   uint16_t m_t3413 = 0;

--- a/srsepc/hdr/mme/s1ap_common.h
+++ b/srsepc/hdr/mme/s1ap_common.h
@@ -44,6 +44,8 @@ typedef struct {
   std::string                         mme_bind_addr;
   std::string                         mme_name;
   std::string                         dns_addr;
+  std::string                         full_net_name;
+  std::string                         short_net_name;
   std::string                         mme_apn;
   bool                                pcap_enable;
   std::string                         pcap_filename;

--- a/srsepc/src/main.cc
+++ b/srsepc/src/main.cc
@@ -88,6 +88,8 @@ void parse_args(all_args_t* args, int argc, char* argv[])
   string   sgi_if_addr;
   string   sgi_if_name;
   string   dns_addr;
+  string   full_net_name;
+  string   short_net_name;
   string   hss_db_file;
   string   hss_auth_algo;
   string   log_filename;
@@ -111,6 +113,8 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     ("mme.mnc",             bpo::value<string>(&mnc)->default_value("01"),                   "Mobile Network Code")
     ("mme.mme_bind_addr",   bpo::value<string>(&mme_bind_addr)->default_value("127.0.0.1"),  "IP address of MME for S1 connection")
     ("mme.dns_addr",        bpo::value<string>(&dns_addr)->default_value("8.8.8.8"),         "IP address of the DNS server for the UEs")
+    ("mme.full_net_name",   bpo::value<string>(&full_net_name)->default_value("Software Radio Systems LTE"), "Full name of the network")
+    ("mme.short_net_name",  bpo::value<string>(&short_net_name)->default_value("srsLTE"),    "Short name of the network")
     ("mme.apn",             bpo::value<string>(&mme_apn)->default_value(""),                 "Set Access Point Name (APN) for data services")
     ("mme.encryption_algo", bpo::value<string>(&encryption_algo)->default_value("EEA0"),     "Set preferred encryption algorithm for NAS layer ")
     ("mme.integrity_algo",  bpo::value<string>(&integrity_algo)->default_value("EIA1"),      "Set preferred integrity protection algorithm for NAS")
@@ -270,6 +274,8 @@ void parse_args(all_args_t* args, int argc, char* argv[])
   args->mme_args.s1ap_args.mme_bind_addr = mme_bind_addr;
   args->mme_args.s1ap_args.mme_name      = mme_name;
   args->mme_args.s1ap_args.dns_addr      = dns_addr;
+  args->mme_args.s1ap_args.full_net_name = full_net_name;
+  args->mme_args.s1ap_args.short_net_name = short_net_name;
   args->mme_args.s1ap_args.mme_apn       = mme_apn;
   args->mme_args.s1ap_args.paging_timer  = paging_timer;
   args->spgw_args.gtpu_bind_addr         = spgw_bind_addr;

--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -44,6 +44,8 @@ nas::nas(const nas_init_t& args, const nas_if_t& itf, srslte::log* nas_log) :
   m_tac(args.tac),
   m_apn(args.apn),
   m_dns(args.dns),
+  m_full_net_name(args.full_net_name),
+  m_short_net_name(args.short_net_name),
   m_t3413(args.paging_timer)
 {
   m_sec_ctx.integ_algo  = args.integ_algo;
@@ -1534,10 +1536,10 @@ bool nas::pack_emm_information(srslte::byte_buffer_t* nas_buffer)
 
   LIBLTE_MME_EMM_INFORMATION_MSG_STRUCT emm_info;
   emm_info.full_net_name_present = true;
-  strncpy(emm_info.full_net_name.name, "Software Radio Systems LTE", LIBLTE_STRING_LEN);
+  memccpy(emm_info.full_net_name.name, m_full_net_name.c_str(), 0, LIBLTE_STRING_LEN);
   emm_info.full_net_name.add_ci   = LIBLTE_MME_ADD_CI_DONT_ADD;
   emm_info.short_net_name_present = true;
-  strncpy(emm_info.short_net_name.name, "srsLTE", LIBLTE_STRING_LEN);
+  memccpy(emm_info.short_net_name.name, m_short_net_name.c_str(), 0, LIBLTE_STRING_LEN);
   emm_info.short_net_name.add_ci = LIBLTE_MME_ADD_CI_DONT_ADD;
 
   emm_info.local_time_zone_present         = false;

--- a/srsepc/src/mme/s1ap_nas_transport.cc
+++ b/srsepc/src/mme/s1ap_nas_transport.cc
@@ -77,6 +77,8 @@ void s1ap_nas_transport::init()
   m_nas_init.tac          = m_s1ap->m_s1ap_args.tac;
   m_nas_init.apn          = m_s1ap->m_s1ap_args.mme_apn;
   m_nas_init.dns          = m_s1ap->m_s1ap_args.dns_addr;
+  m_nas_init.full_net_name  = m_s1ap->m_s1ap_args.full_net_name;
+  m_nas_init.short_net_name = m_s1ap->m_s1ap_args.short_net_name;
   m_nas_init.paging_timer = m_s1ap->m_s1ap_args.paging_timer;
   m_nas_init.integ_algo   = m_s1ap->m_s1ap_args.integrity_algo;
   m_nas_init.cipher_algo  = m_s1ap->m_s1ap_args.encryption_algo;


### PR DESCRIPTION
Hello!
This change will allow configuring the full network name and the short network name in the EMM information.

Thanks in advance!