### PR TITLE
Add subnet mask of interface for the SGi connection

### DIFF
--- a/srsepc/hdr/spgw/spgw.h
+++ b/srsepc/hdr/spgw/spgw.h
@@ -46,6 +46,7 @@ typedef struct {
   std::string gtpu_bind_addr;
   std::string sgi_if_addr;
   std::string sgi_if_name;
+  std::string sgi_if_netmask;
   uint32_t    max_paging_queue;
 } spgw_args_t;
 

--- a/srsepc/src/main.cc
+++ b/srsepc/src/main.cc
@@ -87,6 +87,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
   string   spgw_bind_addr;
   string   sgi_if_addr;
   string   sgi_if_name;
+  string   sgi_if_netmask;
   string   dns_addr;
   string   hss_db_file;
   string   hss_auth_algo;
@@ -119,6 +120,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
     ("spgw.gtpu_bind_addr", bpo::value<string>(&spgw_bind_addr)->default_value("127.0.0.1"), "IP address of SP-GW for the S1-U connection")
     ("spgw.sgi_if_addr",    bpo::value<string>(&sgi_if_addr)->default_value("176.16.0.1"),   "IP address of TUN interface for the SGi connection")
     ("spgw.sgi_if_name",    bpo::value<string>(&sgi_if_name)->default_value("srs_spgw_sgi"), "Name of TUN interface for the SGi connection")
+    ("spgw.sgi_if_netmask", bpo::value<string>(&sgi_if_netmask)->default_value("255.255.255.0"),  "IP mask of TUN interface for the SGi connection")
     ("spgw.max_paging_queue", bpo::value<uint32_t>(&max_paging_queue)->default_value(100), "Max number of packets in paging queue")
 
     ("pcap.enable",   bpo::value<bool>(&args->mme_args.s1ap_args.pcap_enable)->default_value(false),         "Enable S1AP PCAP")
@@ -275,6 +277,7 @@ void parse_args(all_args_t* args, int argc, char* argv[])
   args->spgw_args.gtpu_bind_addr         = spgw_bind_addr;
   args->spgw_args.sgi_if_addr            = sgi_if_addr;
   args->spgw_args.sgi_if_name            = sgi_if_name;
+  args->spgw_args.sgi_if_netmask         = sgi_if_netmask;
   args->spgw_args.max_paging_queue       = max_paging_queue;
   args->hss_args.db_file                 = hss_db_file;
 

--- a/srsepc/src/spgw/gtpc.cc
+++ b/srsepc/src/spgw/gtpc.cc
@@ -567,11 +567,12 @@ int spgw::gtpc::init_ue_ip(spgw_args_t* args, const std::map<std::string, uint64
     }
   }
 
-  // XXX TODO add an upper bound to ip addr range via config, use 254 for now
+  uint32_t hosts_bound = (~ntohl(inet_addr(args->sgi_if_netmask.c_str()))) - 1;
+
   // first address is allocated to the epc tun interface, start w/next addr
-  for (uint32_t n = 1; n < 254; ++n) {
+  for (uint32_t n = 1; n < hosts_bound; ++n) {
     struct in_addr ue_addr;
-    ue_addr.s_addr = inet_addr(args->sgi_if_addr.c_str()) + htonl(n);
+    ue_addr.s_addr = htonl(ntohl(inet_addr(args->sgi_if_addr.c_str())) + n);
 
     std::map<std::string, uint64_t>::const_iterator iter = ip_to_imsi.find(inet_ntoa(ue_addr));
     if (iter != ip_to_imsi.end()) {

--- a/srsepc/src/spgw/gtpu.cc
+++ b/srsepc/src/spgw/gtpu.cc
@@ -155,7 +155,7 @@ int spgw::gtpu::init_sgi(spgw_args_t* args)
   }
 
   ifr.ifr_netmask.sa_family                                = AF_INET;
-  ((struct sockaddr_in*)&ifr.ifr_netmask)->sin_addr.s_addr = inet_addr("255.255.255.0");
+  ((struct sockaddr_in*)&ifr.ifr_netmask)->sin_addr.s_addr = inet_addr(args->sgi_if_netmask.c_str());
   if (ioctl(sgi_sock, SIOCSIFNETMASK, &ifr) < 0) {
     m_gtpu_log->error("Failed to set TUN interface Netmask. Error: %s\n", strerror(errno));
     close(m_sgi);


### PR DESCRIPTION
Hey!
This change will allow allocating more than 254 addresses for UEs.
I am pretty terrified that I missed something, so I would like your close inspection and your professional opinion.

Thanks for dedicating time!